### PR TITLE
PRSD-573: Switches to multiple AZs

### DIFF
--- a/terraform/environment_template/main.tf.template
+++ b/terraform/environment_template/main.tf.template
@@ -30,6 +30,7 @@ module "networking" {
   source                     = "../modules/networking"
   vpc_cidr_block             = "<environment cidr block>"
   environment_name           = local.environment_name
+  number_of_availability_zones = 2
   number_of_isolated_subnets = local.multi_az ? 2 : 1
   integration_domains = [
     <Domains for 3rd party integrations in this environment>

--- a/terraform/environment_template/outputs.tf.template
+++ b/terraform/environment_template/outputs.tf.template
@@ -1,5 +1,5 @@
-output "public_subnet_id" {
-  value = module.networking.public_subnet.id
+output "public_subnet_ids" {
+  value = module.networking.public_subnet[*].id
 }
 
 output "vpc_id" {

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -27,11 +27,11 @@ locals {
 }
 
 module "networking" {
-  source                     = "../modules/networking"
-  vpc_cidr_block             = "10.1.0.0/16"
-  environment_name           = local.environment_name
+  source                       = "../modules/networking"
+  vpc_cidr_block               = "10.1.0.0/16"
+  environment_name             = local.environment_name
   number_of_availability_zones = 2
-  number_of_isolated_subnets = local.multi_az ? 2 : 1
+  number_of_isolated_subnets   = local.multi_az ? 2 : 1
   integration_domains = [
     "oidc.integration.account.gov.uk",
     "api.os.uk",

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -30,6 +30,7 @@ module "networking" {
   source                     = "../modules/networking"
   vpc_cidr_block             = "10.1.0.0/16"
   environment_name           = local.environment_name
+  number_of_availability_zones = 2
   number_of_isolated_subnets = local.multi_az ? 2 : 1
   integration_domains = [
     "oidc.integration.account.gov.uk",

--- a/terraform/integration/outputs.tf
+++ b/terraform/integration/outputs.tf
@@ -1,5 +1,5 @@
-output "public_subnet_id" {
-  value = module.networking.public_subnet.id
+output "public_subnet_ids" {
+  value = module.networking.public_subnet[*].id
 }
 
 output "vpc_id" {

--- a/terraform/modules/networking/firewall.tf
+++ b/terraform/modules/networking/firewall.tf
@@ -46,8 +46,13 @@ resource "aws_networkfirewall_firewall" "main" {
   name                = "network-firewall-${var.environment_name}"
   firewall_policy_arn = aws_networkfirewall_firewall_policy.main.arn
   vpc_id              = aws_vpc.main.id
-  subnet_mapping {
-    subnet_id = aws_subnet.firewall.id
+
+  dynamic "subnet_mapping" {
+    for_each = aws_subnet.firewall
+
+    content {
+      subnet_id = subnet_mapping.value.id
+    }
   }
 }
 

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -4,7 +4,7 @@ output "vpc" {
 }
 
 output "nat_gateway_ip" {
-  value = aws_eip.nat_gateway.public_ip
+  value = aws_eip.nat_gateway[*].public_ip
 }
 
 output "public_subnet" {
@@ -18,7 +18,7 @@ output "private_subnet" {
 }
 
 output "isolated_subnets" {
-  value       = aws_subnet.isolated_subnets
+  value       = aws_subnet.isolated_subnet
   description = "var.number_of_isolated_subnets /22 subnets for db and redis - 2 required when using multi-AZ rds"
 }
 

--- a/terraform/modules/networking/route_table.tf
+++ b/terraform/modules/networking/route_table.tf
@@ -13,54 +13,61 @@ resource "aws_route_table" "to_internet_gateway" {
 }
 
 resource "aws_route_table_association" "public" {
-  subnet_id      = aws_subnet.public_subnet.id
+  count = var.number_of_availability_zones
+  subnet_id      = aws_subnet.public_subnet[count.index].id
   route_table_id = aws_route_table.to_internet_gateway.id
 }
 
 # Firewalled subnets should route internet traffic to the Firewall
 resource "aws_route_table" "private_to_firewall" {
+  count = var.number_of_availability_zones
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name = "to-firewall-route-table-${var.environment_name}"
+    Name = "to-firewall-route-table-${var.environment_name}-${data.aws_availability_zones.available.names[count.index]}"
   }
 }
 
 resource "aws_route" "private_to_firewall" {
-  route_table_id         = aws_route_table.private_to_firewall.id
+  count = var.number_of_availability_zones
+  route_table_id         = aws_route_table.private_to_firewall[count.index].id
   destination_cidr_block = "0.0.0.0/0"
-  vpc_endpoint_id        = one(one(one(aws_networkfirewall_firewall.main.firewall_status).sync_states).attachment).endpoint_id
+  vpc_endpoint_id        = one(element(one(aws_networkfirewall_firewall.main.firewall_status).sync_states[*], count.index).attachment).endpoint_id
 }
 
 resource "aws_route_table_association" "private" {
-  subnet_id      = aws_subnet.private_subnet.id
-  route_table_id = aws_route_table.private_to_firewall.id
+  count = var.number_of_availability_zones
+  subnet_id      = aws_subnet.private_subnet[count.index].id
+  route_table_id = aws_route_table.private_to_firewall[count.index].id
 }
 
 resource "aws_route_table_association" "isolated" {
   count          = var.number_of_isolated_subnets
-  subnet_id      = aws_subnet.isolated_subnets[count.index].id
-  route_table_id = aws_route_table.private_to_firewall.id
+  subnet_id      = aws_subnet.isolated_subnet[count.index].id
+  route_table_id = aws_route_table.private_to_firewall[count.index].id
 }
 
 # Firewall should forward to the NAT Gateway
 resource "aws_route_table" "to_nat_gateway" {
+  count = var.number_of_availability_zones
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name = "to-nat-route-table-${var.environment_name}"
+    Name = "to-nat-route-table-${var.environment_name}-${data.aws_availability_zones.available.names[count.index]}"
   }
 }
 
 resource "aws_route" "to_nat_gateway" {
-  route_table_id         = aws_route_table.to_nat_gateway.id
+  count = var.number_of_availability_zones
+  route_table_id         = aws_route_table.to_nat_gateway[count.index].id
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.nat_gateway.id
+  nat_gateway_id         = aws_nat_gateway.nat_gateway[count.index].id
 }
 
 resource "aws_route_table_association" "firewall" {
-  subnet_id      = aws_subnet.firewall.id
-  route_table_id = aws_route_table.to_nat_gateway.id
+  count = var.number_of_availability_zones
+  subnet_id      = aws_subnet.firewall[count.index].id
+  route_table_id = aws_route_table.to_nat_gateway[count.index].id
 }
 
 # NAT gateway should send internet bound traffic out to the gateway
@@ -79,16 +86,25 @@ resource "aws_route" "nat_gateway_to_internet" {
 }
 
 resource "aws_route_table_association" "nat_gateway" {
-  subnet_id      = aws_subnet.nat_gateway.id
+  count = var.number_of_availability_zones
+  subnet_id      = aws_subnet.nat_gateway[count.index].id
   route_table_id = aws_route_table.nat_gateway_subnet_route_table.id
 }
 
 # For return traffic the Internet Gateway will route traffic to the NAT Gateway
 # Then the NAT Gateway should route traffic destined for firewalled subnets back to the Firewall
-resource "aws_route" "nat_gateway_back_to_firewall" {
-  for_each = { for subnet in concat([aws_subnet.private_subnet], aws_subnet.isolated_subnets) : subnet.tags.Name => subnet }
+resource "aws_route" "nat_gateway_back_to_firewall_private" {
+  count = length(aws_subnet.private_subnet)
   # More specific routes override less specific ones (by prefix length)
   route_table_id         = aws_route_table.nat_gateway_subnet_route_table.id
-  destination_cidr_block = each.value.cidr_block
-  vpc_endpoint_id        = one(one(one(aws_networkfirewall_firewall.main.firewall_status).sync_states).attachment).endpoint_id
+  destination_cidr_block = aws_subnet.private_subnet[count.index].cidr_block
+  vpc_endpoint_id        = one(element(one(aws_networkfirewall_firewall.main.firewall_status).sync_states[*], count.index).attachment).endpoint_id
+}
+
+resource "aws_route" "nat_gateway_back_to_firewall_isolated" {
+  count = length(aws_subnet.isolated_subnet)
+  # More specific routes override less specific ones (by prefix length)
+  route_table_id         = aws_route_table.nat_gateway_subnet_route_table.id
+  destination_cidr_block = aws_subnet.isolated_subnet[count.index].cidr_block
+  vpc_endpoint_id        = one(element(one(aws_networkfirewall_firewall.main.firewall_status).sync_states[*], count.index).attachment).endpoint_id
 }

--- a/terraform/modules/networking/route_table.tf
+++ b/terraform/modules/networking/route_table.tf
@@ -13,14 +13,14 @@ resource "aws_route_table" "to_internet_gateway" {
 }
 
 resource "aws_route_table_association" "public" {
-  count = var.number_of_availability_zones
+  count          = var.number_of_availability_zones
   subnet_id      = aws_subnet.public_subnet[count.index].id
   route_table_id = aws_route_table.to_internet_gateway.id
 }
 
 # Firewalled subnets should route internet traffic to the Firewall
 resource "aws_route_table" "private_to_firewall" {
-  count = var.number_of_availability_zones
+  count  = var.number_of_availability_zones
   vpc_id = aws_vpc.main.id
 
   tags = {
@@ -29,14 +29,14 @@ resource "aws_route_table" "private_to_firewall" {
 }
 
 resource "aws_route" "private_to_firewall" {
-  count = var.number_of_availability_zones
+  count                  = var.number_of_availability_zones
   route_table_id         = aws_route_table.private_to_firewall[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   vpc_endpoint_id        = one(element(one(aws_networkfirewall_firewall.main.firewall_status).sync_states[*], count.index).attachment).endpoint_id
 }
 
 resource "aws_route_table_association" "private" {
-  count = var.number_of_availability_zones
+  count          = var.number_of_availability_zones
   subnet_id      = aws_subnet.private_subnet[count.index].id
   route_table_id = aws_route_table.private_to_firewall[count.index].id
 }
@@ -49,7 +49,7 @@ resource "aws_route_table_association" "isolated" {
 
 # Firewall should forward to the NAT Gateway
 resource "aws_route_table" "to_nat_gateway" {
-  count = var.number_of_availability_zones
+  count  = var.number_of_availability_zones
   vpc_id = aws_vpc.main.id
 
   tags = {
@@ -58,14 +58,14 @@ resource "aws_route_table" "to_nat_gateway" {
 }
 
 resource "aws_route" "to_nat_gateway" {
-  count = var.number_of_availability_zones
+  count                  = var.number_of_availability_zones
   route_table_id         = aws_route_table.to_nat_gateway[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.nat_gateway[count.index].id
 }
 
 resource "aws_route_table_association" "firewall" {
-  count = var.number_of_availability_zones
+  count          = var.number_of_availability_zones
   subnet_id      = aws_subnet.firewall[count.index].id
   route_table_id = aws_route_table.to_nat_gateway[count.index].id
 }
@@ -86,7 +86,7 @@ resource "aws_route" "nat_gateway_to_internet" {
 }
 
 resource "aws_route_table_association" "nat_gateway" {
-  count = var.number_of_availability_zones
+  count          = var.number_of_availability_zones
   subnet_id      = aws_subnet.nat_gateway[count.index].id
   route_table_id = aws_route_table.nat_gateway_subnet_route_table.id
 }

--- a/terraform/modules/networking/subnet.tf
+++ b/terraform/modules/networking/subnet.tf
@@ -11,7 +11,7 @@ locals {
 }
 
 resource "aws_subnet" "nat_gateway" {
-  count = var.number_of_availability_zones
+  count             = var.number_of_availability_zones
   availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = cidrsubnet(local.nat_gateway_cidr_10, 2, count.index)
   vpc_id            = aws_vpc.main.id
@@ -20,7 +20,7 @@ resource "aws_subnet" "nat_gateway" {
 
 # tfsec:ignore:aws-ec2-no-public-ip-subnet
 resource "aws_subnet" "public_subnet" {
-  count = var.number_of_availability_zones
+  count                   = var.number_of_availability_zones
   availability_zone       = data.aws_availability_zones.available.names[count.index]
   cidr_block              = cidrsubnet(local.public_cidr_10, 2, count.index)
   vpc_id                  = aws_vpc.main.id
@@ -29,7 +29,7 @@ resource "aws_subnet" "public_subnet" {
 }
 
 resource "aws_subnet" "firewall" {
-  count = var.number_of_availability_zones
+  count             = var.number_of_availability_zones
   availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = cidrsubnet(local.firewall_cidr_10, 2, count.index)
   vpc_id            = aws_vpc.main.id
@@ -37,7 +37,7 @@ resource "aws_subnet" "firewall" {
 }
 
 resource "aws_subnet" "private_subnet" {
-  count = var.number_of_availability_zones
+  count             = var.number_of_availability_zones
   availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = cidrsubnet(local.private_cidr_10, 2, count.index)
   vpc_id            = aws_vpc.main.id

--- a/terraform/modules/networking/subnet.tf
+++ b/terraform/modules/networking/subnet.tf
@@ -11,39 +11,43 @@ locals {
 }
 
 resource "aws_subnet" "nat_gateway" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = local.nat_gateway_cidr_10
+  count = var.number_of_availability_zones
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(local.nat_gateway_cidr_10, 2, count.index)
   vpc_id            = aws_vpc.main.id
-  tags              = { Name = "nat-gateway-${var.environment_name}" }
+  tags              = { Name = "nat-gateway-${var.environment_name}-${data.aws_availability_zones.available.names[count.index]}" }
 }
 
 # tfsec:ignore:aws-ec2-no-public-ip-subnet
 resource "aws_subnet" "public_subnet" {
-  availability_zone       = data.aws_availability_zones.available.names[0]
-  cidr_block              = local.public_cidr_10
+  count = var.number_of_availability_zones
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  cidr_block              = cidrsubnet(local.public_cidr_10, 2, count.index)
   vpc_id                  = aws_vpc.main.id
   map_public_ip_on_launch = true
-  tags                    = { Name = "public-subnet-${var.environment_name}" }
+  tags                    = { Name = "public-subnet-${var.environment_name}-${data.aws_availability_zones.available.names[count.index]}" }
 }
 
 resource "aws_subnet" "firewall" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = local.firewall_cidr_10
+  count = var.number_of_availability_zones
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(local.firewall_cidr_10, 2, count.index)
   vpc_id            = aws_vpc.main.id
-  tags              = { Name = "vpc-network-firewall-subnet-${var.environment_name}" }
+  tags              = { Name = "vpc-network-firewall-subnet-${var.environment_name}-${data.aws_availability_zones.available.names[count.index]}" }
 }
 
 resource "aws_subnet" "private_subnet" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  cidr_block        = local.private_cidr_10
+  count = var.number_of_availability_zones
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  cidr_block        = cidrsubnet(local.private_cidr_10, 2, count.index)
   vpc_id            = aws_vpc.main.id
-  tags              = { Name = "vpc-private-subnet-${var.environment_name}" }
+  tags              = { Name = "vpc-private-subnet-${var.environment_name}-${data.aws_availability_zones.available.names[count.index]}" }
 }
 
-resource "aws_subnet" "isolated_subnets" {
+resource "aws_subnet" "isolated_subnet" {
   count             = var.number_of_isolated_subnets
   availability_zone = data.aws_availability_zones.available.names[count.index]
   cidr_block        = cidrsubnet(local.isolated_cidr_10, 2, count.index)
   vpc_id            = aws_vpc.main.id
-  tags              = { Name = "vpc-isolated-subnet-${data.aws_availability_zones.available.names[count.index]}" }
+  tags              = { Name = "vpc-isolated-subnet-${var.environment_name}-${data.aws_availability_zones.available.names[count.index]}" }
 }

--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -13,13 +13,13 @@ variable "vpc_cidr_block" {
 }
 
 variable "number_of_availability_zones" {
-  default = 2
-  description = "Number of availability zones we will deploy to; must be 2 < x < number of available AZs"
+  default     = 2
+  description = "Number of availability zones we will deploy to; must be 2 <= x <= number of available AZs"
 }
 
 variable "number_of_isolated_subnets" {
   default     = 1
-  description = "Each isolated subnet is located in a different AZ; must be 1 < x < number of available AZs"
+  description = "Each isolated subnet is located in a different AZ; must be 1 <= x <= number of available AZs"
 }
 
 variable "integration_domains" {

--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -12,9 +12,14 @@ variable "vpc_cidr_block" {
   description = "A collection of IP addresses to be allocated to VPC."
 }
 
+variable "number_of_availability_zones" {
+  default = 2
+  description = "Number of availability zones we will deploy to; must be 2 < x < number of available AZs"
+}
+
 variable "number_of_isolated_subnets" {
   default     = 1
-  description = "Each isolated subnet is located in a different AZ; must be 0 < x < number of available AZs"
+  description = "Each isolated subnet is located in a different AZ; must be 1 < x < number of available AZs"
 }
 
 variable "integration_domains" {


### PR DESCRIPTION
Switching to multiple AZs for public and private subnets (isolated subnet still tied to whether RDS is using multi-AZ, which we might not want to do in `integration` for cost purposes). ADR to updated in [the open webapp PR](https://github.com/communitiesuk/prsdb-webapp/pull/85).