### PR TITLE
PRSD-748: Updates OIDC iam policy to allow access from webapp

### DIFF
--- a/terraform/modules/github_actions_access/iam.tf
+++ b/terraform/modules/github_actions_access/iam.tf
@@ -24,7 +24,8 @@ data "aws_iam_policy_document" "github_actions_terraform_plan_assume_role" {
     condition {
       test = "StringLike"
       values = [
-        "repo:communitiesuk/prsdb-infra:*"
+        "repo:communitiesuk/prsdb-infra:*",
+        "repo:communitiesuk/prsdb-webapp:*",
       ]
       variable = "token.actions.githubusercontent.com:sub"
     }
@@ -73,9 +74,10 @@ data "aws_iam_policy_document" "github_actions_terraform_admin_assume_role" {
     }
 
     condition {
-      test = "StringEquals"
+      test = "StringLike"
       values = [
         "repo:communitiesuk/prsdb-infra:*",
+        "repo:communitiesuk/prsdb-webapp:*",
       ]
       variable = "token.actions.githubusercontent.com:sub"
     }
@@ -108,7 +110,7 @@ data "aws_iam_policy_document" "github_actions_push_ecr_assume_role" {
     }
 
     condition {
-      test = "StringEquals"
+      test = "StringLike"
       values = [
         "repo:communitiesuk/prsdb-webapp:*",
       ]


### PR DESCRIPTION
Allows webapp repo to assume plan & apply roles, and also fixes a matching issue on OIDC access that affects both Apply and ECR push. Note: Because this would have prevented the Apply step from completing it has been terraform applied manually.