### PR TITLE
PRSD-790: Adds SSM parameters

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -30,13 +30,13 @@ TODO
 
 TODO: Document the request process for the domain names and certificates
 
-### Setting up the ECR repository, Secrets and task definition
+### Setting up the ECR repository, Secrets, SSM parameters, and task definition
 
 - We also need to create the ECR repository, Secrets, and initial task definition before we can bring up the ECS service.
 - Make sure that the `terraform.tfvars` file that was created in the previous step contains the line `task_definition_created = false`
-- Still inside your `terraform/<environment name>` folder, run `terraform plan -target module.ecr -target module.secrets`.
-- If the output of the plan looks correct, run `terraform apply -target module.ecr -target module.secrets` to create the ECR repository and secrets.
-- For the app secrets, terraform will create the secrets but not populate them. Ask the team lead where you can find the appropriate secret values, and then populate them via the AWS console.
+- Still inside your `terraform/<environment name>` folder, run `terraform plan -target module.ecr -target module.secrets -target module.ssm`.
+- If the output of the plan looks correct, run `terraform apply -target module.ecr -target module.secrets -target module.ssm` to create the ECR repository, secrets, and SSM parameters.
+- Terraform will create the webapp secrets and SSM parameters but not populate them. Ask the team lead where you can find the appropriate values, and then populate them via the AWS console.
 - To create the task definition, in `terraform/<environment name>/ecs_task_definition`, if you haven't already, remove the `.template` from the end of any file names in the folder, and replace all instances of the string `<environment name>` with your actual environment name.
 - Next, cd into `terraform/<environment name>/ecs_task_definition` and run `terraform init` followed by `terraform plan`. This should show you one resource being created - the task definition. If the output looks correct, run `terraform apply`.
 

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -1,0 +1,35 @@
+data "aws_iam_role" "ecs_task_execution" {
+  name = "${local.environment_name}-ecs-task-execution"
+}
+
+data "aws_iam_role" "webapp_ecs_task" {
+  name = "${local.environment_name}-webapp-ecs-task"
+}
+
+data "aws_ssm_parameter" "one_login_public_key" {
+  name = "${local.environment_name}-one-login-public-key"
+}
+
+data "aws_ssm_parameter" "one_login_client_id" {
+  name = "${local.environment_name}-one-login-client-id"
+}
+
+data "aws_ssm_parameter" "one_login_issuer_url" {
+  name = "${local.environment_name}-one-login-issuer-url"
+}
+
+data "aws_secretsmanager_secret" "database_password" {
+  name = "tf-${local.environment_name}-prsdb-database-password"
+}
+
+data "aws_secretsmanager_secret" "one_login_private_key" {
+  name = "tf-${local.environment_name}-one-login-private-key"
+}
+
+data "aws_secretsmanager_secret" "notify_api_key" {
+  name = "tf-${local.environment_name}-notify-api-key"
+}
+
+data "aws_secretsmanager_secret" "os_places_api_key" {
+  name = "tf-${local.environment_name}-os-places-api-key"
+}

--- a/terraform/modules/secrets/kms.tf
+++ b/terraform/modules/secrets/kms.tf
@@ -1,6 +1,10 @@
 resource "aws_kms_key" "prsdb_webapp_secrets" {
   description         = "prsdb-webapp-secrets-${var.environment_name}"
   enable_key_rotation = true
+
+  tags = {
+    "terraform-plan-read" = true
+  }
 }
 
 resource "aws_kms_alias" "prsdb_webapp_secrets" {

--- a/terraform/modules/ssm/main.tf
+++ b/terraform/modules/ssm/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~>1.9.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>5.0"
+    }
+  }
+}

--- a/terraform/modules/ssm/parameters.tf
+++ b/terraform/modules/ssm/parameters.tf
@@ -3,7 +3,7 @@
 resource "aws_ssm_parameter" "one_login_public_key" {
   name  = "${var.environment_name}-one-login-public-key"
   type  = "String"
-  value = "default" # To be set manually on AWS
+  value = "default_to_be_set_manually" # To be set manually on AWS
 
   lifecycle {
     ignore_changes = ["value"]
@@ -13,7 +13,7 @@ resource "aws_ssm_parameter" "one_login_public_key" {
 resource "aws_ssm_parameter" "one_login_client_id" {
   name  = "${var.environment_name}-one-login-client-id"
   type  = "String"
-  value = "default" # To be set manually on AWS
+  value = "default_to_be_set_manually" # To be set manually on AWS
 
   lifecycle {
     ignore_changes = ["value"]
@@ -23,7 +23,7 @@ resource "aws_ssm_parameter" "one_login_client_id" {
 resource "aws_ssm_parameter" "one_login_issuer_url" {
   name  = "${var.environment_name}-one-login-issuer-url"
   type  = "String"
-  value = "default" # To be set manually on AWS
+  value = "default_to_be_set_manually" # To be set manually on AWS
 
   lifecycle {
     ignore_changes = ["value"]

--- a/terraform/modules/ssm/parameters.tf
+++ b/terraform/modules/ssm/parameters.tf
@@ -1,0 +1,31 @@
+# Resource - specific parameters are to be created in their respective modules
+
+resource "aws_ssm_parameter" "one_login_public_key" {
+  name  = "${var.environment_name}-one-login-public-key"
+  type  = "String"
+  value = "default" # To be set manually on AWS
+
+  lifecycle {
+    ignore_changes = ["value"]
+  }
+}
+
+resource "aws_ssm_parameter" "one_login_client_id" {
+  name  = "${var.environment_name}-one-login-client-id"
+  type  = "String"
+  value = "default" # To be set manually on AWS
+
+  lifecycle {
+    ignore_changes = ["value"]
+  }
+}
+
+resource "aws_ssm_parameter" "one_login_issuer_url" {
+  name  = "${var.environment_name}-one-login-issuer-url"
+  type  = "String"
+  value = "default" # To be set manually on AWS
+
+  lifecycle {
+    ignore_changes = ["value"]
+  }
+}

--- a/terraform/modules/ssm/variables.tf
+++ b/terraform/modules/ssm/variables.tf
@@ -1,0 +1,8 @@
+variable "environment_name" {
+  description = "must be one of: integration, test"
+  type        = string
+  validation {
+    condition     = contains(["integration", "test"], var.environment_name)
+    error_message = "Environment must be one of: integration, test"
+  }
+}


### PR DESCRIPTION
To be rebased and targeted at main when PR #24 is merged. Includes a small tidying up of the task definition module. There is a bigger refactor I'd like to do to parameterize the task definition module and move it to `./modules` but I'll do that in a separate PR once we have finished adding to it.