### PR TITLE
PRSD-751: Changes Redis version to 7.1

### DIFF
--- a/terraform/modules/elasticache/redis.tf
+++ b/terraform/modules/elasticache/redis.tf
@@ -13,7 +13,7 @@ resource "aws_elasticache_replication_group" "main" {
   automatic_failover_enabled  = var.highly_available ? true : false
   description                 = "Redis replication group, consisting of a single node, or a primary node and a replica."
   engine                      = "redis"
-  engine_version              = "7.4" # Unlike RDS, this should not cause state drift
+  engine_version              = "7.1" # Unlike RDS, this should not cause state drift
   final_snapshot_identifier   = "${var.environment_name}-database-final-snapshot"
   maintenance_window          = var.maintenance_window
   multi_az_enabled            = var.highly_available ? true : false


### PR DESCRIPTION
7.1 is the current maximum version supported by elasticache https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/supported-engine-versions.html#supported-engine-versions.redis