### PR TITLE
PRSD-751: Uses correct subnet group type for redis

### DIFF
--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -141,7 +141,7 @@ module "redis" {
   node_type                = "cache.t4g.micro"
   redis_password           = module.secrets.redis_password.result
   redis_port               = local.redis_port
-  redis_subnet_group_name  = module.networking.db_subnet_group_name
+  redis_subnet_group_name  = module.networking.redis_subnet_group_name
   snapshot_retention_limit = 7
   vpc_id                   = module.networking.vpc.id
 }

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -28,3 +28,8 @@ output "db_subnet_group_name" {
   description = "Name of the db subnet group"
 }
 
+output "redis_subnet_group_name" {
+  value       = aws_elasticache_subnet_group.main.name
+  description = "Name of the redis subnet group"
+}
+

--- a/terraform/modules/networking/subnet.tf
+++ b/terraform/modules/networking/subnet.tf
@@ -55,3 +55,7 @@ resource "aws_db_subnet_group" "main" {
   subnet_ids = aws_subnet.isolated_subnet[*].id
 }
 
+resource "aws_elasticache_subnet_group" "main" {
+  name       = "${var.environment_name}-redis-subnet-group"
+  subnet_ids = aws_subnet.isolated_subnet[*].id
+}


### PR DESCRIPTION
It seems aws distinguishes between different subnet group types and I missed this.

(I have also terraform applied this locally to make sure there are no more gotchas from this ticket...)