### PR TITLE
PRSD-1000: Add quarantine S3 bucket

### DIFF
--- a/terraform/environment_template/main.tf.template
+++ b/terraform/environment_template/main.tf.template
@@ -170,3 +170,11 @@ module "ecs_service" {
   private_subnet_ids        = module.networking.private_subnets[*].id
   vpc_id                    = module.networking.vpc.id
 }
+
+module "s3_bucket" {
+  source                             = "../modules/s3_bucket"
+  bucket_name                        = "prsdb-quarantine-<environment name>"
+  access_log_bucket_name             = "prsdb-quarantine-access-logs-<environment name>"
+  noncurrent_version_expiration_days = 700
+  access_s3_log_expiration_days      = 700
+}

--- a/terraform/environment_template/main.tf.template
+++ b/terraform/environment_template/main.tf.template
@@ -171,10 +171,8 @@ module "ecs_service" {
   vpc_id                    = module.networking.vpc.id
 }
 
-module "s3_bucket" {
-  source                             = "../modules/s3_bucket"
-  bucket_name                        = "prsdb-quarantine-<environment name>"
-  access_log_bucket_name             = "prsdb-quarantine-access-logs-<environment name>"
-  noncurrent_version_expiration_days = 700
-  access_s3_log_expiration_days      = 700
+module "file_upload" {
+  source = "../modules/file_upload"
+  environment_name = local.environment_name
+  webapp_task_execution_role_name = module.ecr.webapp_ecs_task_role_name
 }

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -185,10 +185,8 @@ module "ecs_service" {
   vpc_id                    = module.networking.vpc.id
 }
 
-module "s3_bucket" {
-  source                             = "../modules/s3_bucket"
-  bucket_name                        = "prsdb-quarantine-integration"
-  access_log_bucket_name             = "prsdb-quarantine-access-logs-integration"
-  noncurrent_version_expiration_days = 700
-  access_s3_log_expiration_days      = 700
+module "file_upload" {
+  source = "../modules/file_upload"
+  environment_name = local.environment_name
+  webapp_task_execution_role_name = module.ecr.webapp_ecs_task_role_name
 }

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -184,3 +184,11 @@ module "ecs_service" {
   private_subnet_ids        = module.networking.private_subnets[*].id
   vpc_id                    = module.networking.vpc.id
 }
+
+module "s3_bucket" {
+  source                             = "../modules/s3_bucket"
+  bucket_name                        = "prsdb-quarantine-integration"
+  access_log_bucket_name             = "prsdb-quarantine-access-logs-integration"
+  noncurrent_version_expiration_days = 700
+  access_s3_log_expiration_days      = 700
+}

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -186,7 +186,7 @@ module "ecs_service" {
 }
 
 module "file_upload" {
-  source = "../modules/file_upload"
-  environment_name = local.environment_name
+  source                          = "../modules/file_upload"
+  environment_name                = local.environment_name
   webapp_task_execution_role_name = module.ecr.webapp_ecs_task_role_name
 }

--- a/terraform/modules/file_upload/main.tf
+++ b/terraform/modules/file_upload/main.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_version = "~>1.9.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>5.0"
+    }
+  }
+}
+
+module "quarantine_bucket" {
+  source                             = "../s3_bucket"
+  bucket_name                        = "prsdb-quarantine-${var.environment_name}"
+  access_log_bucket_name             = "prsdb-quarantine-access-logs-${var.environment_name}"
+  noncurrent_version_expiration_days = 700
+  access_s3_log_expiration_days      = 700
+  kms_key_arn                        = aws_kms_key.quarantine_bucket_encryption_key.arn
+}
+
+resource "aws_kms_key" "quarantine_bucket_encryption_key" {
+  description         = "Quarantine bucket encryption key"
+  enable_key_rotation = true
+}
+
+resource "aws_kms_alias" "quarantine_bucket_encryption_key" {
+  name          = "alias/quarantine-encryption-${var.environment_name}"
+  target_key_id = aws_kms_key.quarantine_bucket_encryption_key.key_id
+}
+
+data "aws_iam_policy_document" "upload_to_quarantine" {
+  statement {
+    sid = "QuarantineS3"
+    actions = [
+      "s3:PutObject",
+    ]
+    resources = [
+      "${module.quarantine_bucket.bucket_arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "upload_to_quarantine" {
+  name   = "upload-to-quarantine"
+  policy = data.aws_iam_policy_document.upload_to_quarantine.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_s3_attachment" {
+  role       = var.webapp_task_execution_role_name
+  policy_arn = aws_iam_policy.upload_to_quarantine.arn
+}

--- a/terraform/modules/file_upload/main.tf
+++ b/terraform/modules/file_upload/main.tf
@@ -28,6 +28,7 @@ resource "aws_kms_alias" "quarantine_bucket_encryption_key" {
   target_key_id = aws_kms_key.quarantine_bucket_encryption_key.key_id
 }
 
+# tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "upload_to_quarantine" {
   statement {
     sid = "QuarantineS3"

--- a/terraform/modules/file_upload/variables.tf
+++ b/terraform/modules/file_upload/variables.tf
@@ -1,0 +1,13 @@
+variable "environment_name" {
+  description = "must be one of: integration, test"
+  type        = string
+  validation {
+    condition     = contains(["integration", "test"], var.environment_name)
+    error_message = "Environment must be one of: integration, test"
+  }
+}
+
+variable "webapp_task_execution_role_name" {
+  description = "Name of the IAM role for the webapp ECS task execution"
+  type        = string
+}

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -184,3 +184,11 @@ module "ecs_service" {
   private_subnet_ids        = module.networking.private_subnets[*].id
   vpc_id                    = module.networking.vpc.id
 }
+
+module "s3_bucket" {
+  source                             = "../modules/s3_bucket"
+  bucket_name                        = "prsdb-quarantine-test"
+  access_log_bucket_name             = "prsdb-quarantine-access-logs-test"
+  noncurrent_version_expiration_days = 700
+  access_s3_log_expiration_days      = 700
+}

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -185,10 +185,8 @@ module "ecs_service" {
   vpc_id                    = module.networking.vpc.id
 }
 
-module "s3_bucket" {
-  source                             = "../modules/s3_bucket"
-  bucket_name                        = "prsdb-quarantine-test"
-  access_log_bucket_name             = "prsdb-quarantine-access-logs-test"
-  noncurrent_version_expiration_days = 700
-  access_s3_log_expiration_days      = 700
+module "file_upload" {
+  source = "../modules/file_upload"
+  environment_name = local.environment_name
+  webapp_task_execution_role_name = module.ecr.webapp_ecs_task_role_name
 }

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -186,7 +186,7 @@ module "ecs_service" {
 }
 
 module "file_upload" {
-  source = "../modules/file_upload"
-  environment_name = local.environment_name
+  source                          = "../modules/file_upload"
+  environment_name                = local.environment_name
   webapp_task_execution_role_name = module.ecr.webapp_ecs_task_role_name
 }


### PR DESCRIPTION
I've added the S3 bucket directly to each main tf file. There are two things I'm unsure of here:
* Should I actually make a module for "file_uploads" (or something) and add the S3 bucket to that instead
* There are a few values that I've just left as their default values that I should maybe set (but I wouldn't know what to)
  * kms_key_arn - KMS key to encrypt bucket and access logs bucket
  * noncurrent_version_expiration_days - not sure what this is for
  * policy - Don't know if there's a reason we'd need anything past the default bucket enforce ssl policy
  * object_lock_enabled - defaults to false. Don't know what we'd user AWS Object Lock for