### PR TITLE
PRSD-NONE: Explicitly turns off inbound-only private dns for VPC endp…

### DIFF
--- a/terraform/modules/networking/vpc_endpoints.tf
+++ b/terraform/modules/networking/vpc_endpoints.tf
@@ -48,4 +48,7 @@ resource "aws_vpc_endpoint" "vpc_endpoints" {
   subnet_ids          = aws_subnet.private_subnet[*].id
   security_group_ids  = [aws_security_group.aws_service_vpc_endpoints.id]
   private_dns_enabled = true
+  dns_options {
+    private_dns_only_for_inbound_resolver_endpoint = false
+  }
 }


### PR DESCRIPTION
…oints

Note: This should be the default, but there appears to be a bug in the provider (which they claim to have fixed...) that ignores the default for s3 endpoints.