### PR TITLE
Feat/prsd 1003 do not accept overly large files

### DIFF
--- a/terraform/modules/frontdoor/waf.tf
+++ b/terraform/modules/frontdoor/waf.tf
@@ -228,19 +228,19 @@ resource "aws_wafv2_web_acl" "main" {
             statement {
               label_match_statement {
                 key   = "awswaf:managed:aws:core-rule-set:CrossSiteScripting_Body"
-                scope = "Label"
+                scope = "LABEL"
               }
             }
             statement {
               label_match_statement {
                 key   = "awswaf:managed:aws:core-rule-set:SizeRestrictions_Body"
-                scope = "Label"
+                scope = "LABEL"
               }
             }
             statement {
               label_match_statement {
                 key   = "awswaf:managed:aws:sql-database:SQLi_Body"
-                scope = "Label"
+                scope = "LABEL"
               }
             }
           }
@@ -264,6 +264,12 @@ resource "aws_wafv2_web_acl" "main" {
           }
         }
       }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "block-exempted-non-file-uploads"
+      sampled_requests_enabled   = true
     }
   }
 

--- a/terraform/modules/frontdoor/waf.tf
+++ b/terraform/modules/frontdoor/waf.tf
@@ -128,7 +128,7 @@ resource "aws_wafv2_web_acl" "main" {
           response_code = 303
           response_header {
             name  = "Location"
-            value = "/landlord/dashboard"
+            value = "/error/file-too-large"
           }
         }
       }
@@ -142,7 +142,7 @@ resource "aws_wafv2_web_acl" "main" {
           }
         }
         # If there are over 9 digits in the Content-Header request, then it's at least a GB
-        regex_string = "^.{8}"
+        regex_string = "^.{10}"
 
         text_transformation {
           priority = 0

--- a/terraform/modules/frontdoor/waf.tf
+++ b/terraform/modules/frontdoor/waf.tf
@@ -217,7 +217,9 @@ resource "aws_wafv2_web_acl" "main" {
     # This rule must be applied after the rules containing AWSManagedRulesCommonRuleSet and AWSManagedRulesSQLiRuleSet
     priority = 8
 
-    action { block {} }
+    action {
+      block {}
+    }
 
     statement {
       and_statement {


### PR DESCRIPTION
Switching to the style of selectively applying rules out of a managed ruleset indicated by this documentation from AWS: https://repost.aws/knowledge-center/waf-upload-blocked-files

Also changes the max size for file uploads to 10 digits and redirects to the correct error page created in the parallel PR.