### PR TITLE
PRSD-none: Add a pull_request_template

### DIFF
--- a/.github/workflows/pull_request_template.md
+++ b/.github/workflows/pull_request_template.md
@@ -1,0 +1,26 @@
+## Ticket number
+
+In the format of "PRSD-XXXX" so that github will auto-link to the jira ticket
+
+## Goal of change
+
+Summary of the problem the PR is trying to solve - usually a 1 sentence summary of the ticket
+
+## Description of main change(s)
+
+Summary of the changes made. These should focus on the functionality that you've changed rather than the actual code
+changes - those will be clear from the PR.
+E.g. Prefer "Adds new endpoint for uploading gas safety certificates to s3" to "Adds new `UploadGasSafetyCertificate`
+controller that accepts a `UploadFileRequest` and uses the `fileUploadService` to upload the file to s3"
+
+## Anything you'd like to highlight to the reviewer?
+
+Include e.g. anything unusual about the PR, where there was some debate over how to implement it, or anywhere you were
+unsure of the approach to take and would like specific feedback.
+
+## Checklist
+Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done
+
+- [ ] Any special release instructions (e.g. set environment variables) have been added as checklist items to a draft PR (merging `main` into `test`) for the next release.
+
+  Make sure to include details such as the name of the variable, where it needs to be set (e.g. AWS Secrets Manager or Parameter Store), and what it should be set to (this might be a location in keeper where a secret value can be found)


### PR DESCRIPTION
Add a pull request template (largely copied from the webapp repo) including a checklist action to document special release actions (such as environment variables that will need setting)

QQ: is there some github setup required so that this gets used?