### PR TITLE
Fix/prsd 1295 unblock secondary domain on cloudfront

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,4 @@
-# PRSDB - Infrastructure
+~~# PRSDB - Infrastructure
 
 This repository contains the Terraform configuration for the infrastructure of the Private Rented Sector Database (PRSDB) service. The main respository for the service, which includes Architecture Decision Records for this infrastructure can be found at https://github.com/communitiesuk/prsdb-webapp
 
@@ -125,6 +125,15 @@ Alternatively, from the project root you can run:
 - `./scripts/ssm_db_connect.sh <environment name>` in bash
 
 This will start the port forwarding session, and copy the database password to your clipboard. You can then connect to the database as set out above.
+
+## Updating existing infrastructure
+After modifying the terraform files, you can run `terraform fmt --recursive` from the root of the repository to format all the files.
+
+Run `terraform plan` to see what changes will be made, and if everything looks correct put up a PR for the changes.
+
+The terraform will applied when your PR is merged.
+
+If there are problems, it may be necessary to make updates manually from the terminal using `terrform apply`, but we should aim to apply terraform via the git pipeline where possible.
 
 ## Setting up a new environment from scratch
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,4 @@
-~~# PRSDB - Infrastructure
+# PRSDB - Infrastructure
 
 This repository contains the Terraform configuration for the infrastructure of the Private Rented Sector Database (PRSDB) service. The main respository for the service, which includes Architecture Decision Records for this infrastructure can be found at https://github.com/communitiesuk/prsdb-webapp
 

--- a/terraform/environment_template/main.tf.template
+++ b/terraform/environment_template/main.tf.template
@@ -63,8 +63,7 @@ module "frontdoor" {
   public_subnet_ids             = module.networking.public_subnets[*].id
   vpc_id                        = module.networking.vpc.id
   application_port              = local.application_port
-  cloudfront_domain_name        = "${local.environment_name}.register-home-to-rent.test.communities.gov.uk"
-  cloudfront_domain_aliases     = [
+  cloudfront_domain_names     = [
     local.app_host,
     local.search_landlord_host,
     local.check_home_to_rent_host

--- a/terraform/environment_template/main.tf.template
+++ b/terraform/environment_template/main.tf.template
@@ -34,6 +34,8 @@ locals {
     redis_port       = 6379
 
   app_host                  = "${local.environment_name}.register-home-to-rent.test.communities.gov.uk"
+  search_landlord_host      = "${local.environment_name}.search-landlord-home-information.test.communities.gov.uk"
+  check_home_to_rent_host   = "${local.environment_name}.check-home-to-rent-registration.test.communities.gov.uk"
   load_balancer_domain_name = "${local.environment_name}.lb.register-home-to-rent.test.communities.gov.uk"
 
   cloudwatch_log_expiration_days = <log retention period>
@@ -62,10 +64,11 @@ module "frontdoor" {
   vpc_id                        = module.networking.vpc.id
   application_port              = local.application_port
   cloudfront_domain_name        = "${local.environment_name}.register-home-to-rent.test.communities.gov.uk"
-  cloudfront_additional_names = [
-                                    "${local.environment_name}.search-landlord-home-information.test.communities.gov.uk",
-                                    "${local.environment_name}.check-home-to-rent-registration.test.communities.gov.uk"
-                                  ]
+  cloudfront_domain_aliases     = [
+    local.app_host,
+    local.search_landlord_host,
+    local.check_home_to_rent_host
+  ]
   load_balancer_domain_name     = "${local.environment_name}.lb.register-home-to-rent.test.communities.gov.uk"
   cloudfront_certificate_arn    = module.certificates.cloudfront_certificate_arn
   load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
@@ -84,7 +87,10 @@ module "certificates" {
 
   cloudfront_domain_name    = local.app_host
   load_balancer_domain_name = local.load_balancer_domain_name
-  cloudfront_additional_names = module.frontdoor.additional_cloudfront_domain_names
+  cloudfront_additional_names = [
+    local.search_landlord_host,
+    local.check_home_to_rent_host
+  ]
   load_balancer_additional_names = [
     "${local.environment_name}.lb.search-landlord-home-information.test.communities.gov.uk",
     "${local.environment_name}.lb.check-home-to-rent-registration.test.communities.gov.uk"

--- a/terraform/environment_template/main.tf.template
+++ b/terraform/environment_template/main.tf.template
@@ -62,6 +62,10 @@ module "frontdoor" {
   vpc_id                        = module.networking.vpc.id
   application_port              = local.application_port
   cloudfront_domain_name        = "${local.environment_name}.register-home-to-rent.test.communities.gov.uk"
+  cloudfront_additional_names = [
+                                    "${local.environment_name}.search-landlord-home-information.test.communities.gov.uk",
+                                    "${local.environment_name}.check-home-to-rent-registration.test.communities.gov.uk"
+                                  ]
   load_balancer_domain_name     = "${local.environment_name}.lb.register-home-to-rent.test.communities.gov.uk"
   cloudfront_certificate_arn    = module.certificates.cloudfront_certificate_arn
   load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
@@ -80,10 +84,7 @@ module "certificates" {
 
   cloudfront_domain_name    = local.app_host
   load_balancer_domain_name = local.load_balancer_domain_name
-  cloudfront_additional_names = [
-    "${local.environment_name}.search-landlord-home-information.test.communities.gov.uk",
-    "${local.environment_name}.check-home-to-rent-registration.test.communities.gov.uk"
-  ]
+  cloudfront_additional_names = module.frontdoor.additional_cloudfront_domain_names
   load_balancer_additional_names = [
     "${local.environment_name}.lb.search-landlord-home-information.test.communities.gov.uk",
     "${local.environment_name}.lb.check-home-to-rent-registration.test.communities.gov.uk"

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -56,12 +56,16 @@ module "frontdoor" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  ssl_certs_created             = var.ssl_certs_created
-  environment_name              = local.environment_name
-  public_subnet_ids             = module.networking.public_subnets[*].id
-  vpc_id                        = module.networking.vpc.id
-  application_port              = local.application_port
-  cloudfront_domain_name        = "${local.environment_name}.register-home-to-rent.test.communities.gov.uk"
+  ssl_certs_created      = var.ssl_certs_created
+  environment_name       = local.environment_name
+  public_subnet_ids      = module.networking.public_subnets[*].id
+  vpc_id                 = module.networking.vpc.id
+  application_port       = local.application_port
+  cloudfront_domain_name = "${local.environment_name}.register-home-to-rent.test.communities.gov.uk"
+  additional_cloudfront_domain_names = [
+    "${local.environment_name}.search-landlord-home-information.test.communities.gov.uk",
+    "${local.environment_name}.check-home-to-rent-registration.test.communities.gov.uk"
+  ]
   load_balancer_domain_name     = "${local.environment_name}.lb.register-home-to-rent.test.communities.gov.uk"
   cloudfront_certificate_arn    = module.certificates.cloudfront_certificate_arn
   load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
@@ -89,12 +93,9 @@ module "certificates" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  cloudfront_domain_name    = local.app_host
-  load_balancer_domain_name = local.load_balancer_domain_name
-  cloudfront_additional_names = [
-    "${local.environment_name}.search-landlord-home-information.test.communities.gov.uk",
-    "${local.environment_name}.check-home-to-rent-registration.test.communities.gov.uk"
-  ]
+  cloudfront_domain_name      = local.app_host
+  load_balancer_domain_name   = local.load_balancer_domain_name
+  cloudfront_additional_names = module.frontdoor.additional_cloudfront_domain_names
   load_balancer_additional_names = [
     "${local.environment_name}.lb.search-landlord-home-information.test.communities.gov.uk",
     "${local.environment_name}.lb.check-home-to-rent-registration.test.communities.gov.uk"

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -34,6 +34,8 @@ locals {
   redis_port       = 6379
 
   app_host                  = "${local.environment_name}.register-home-to-rent.test.communities.gov.uk"
+  search_landlord_host      = "${local.environment_name}.search-landlord-home-information.test.communities.gov.uk"
+  check_home_to_rent_host   = "${local.environment_name}.check-home-to-rent-registration.test.communities.gov.uk"
   load_balancer_domain_name = "${local.environment_name}.lb.register-home-to-rent.test.communities.gov.uk"
 
   cloudwatch_log_expiration_days = 60
@@ -56,17 +58,18 @@ module "frontdoor" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  ssl_certs_created      = var.ssl_certs_created
-  environment_name       = local.environment_name
-  public_subnet_ids      = module.networking.public_subnets[*].id
-  vpc_id                 = module.networking.vpc.id
-  application_port       = local.application_port
-  cloudfront_domain_name = "${local.environment_name}.register-home-to-rent.test.communities.gov.uk"
-  additional_cloudfront_domain_names = [
-    "${local.environment_name}.search-landlord-home-information.test.communities.gov.uk",
-    "${local.environment_name}.check-home-to-rent-registration.test.communities.gov.uk"
+  ssl_certs_created             = var.ssl_certs_created
+  environment_name              = local.environment_name
+  public_subnet_ids             = module.networking.public_subnets[*].id
+  vpc_id                        = module.networking.vpc.id
+  application_port              = local.application_port
+  cloudfront_domain_name        = local.app_host
+  cloudfront_domain_aliases     = [
+    local.app_host,
+    local.search_landlord_host,
+    local.check_home_to_rent_host
   ]
-  load_balancer_domain_name     = "${local.environment_name}.lb.register-home-to-rent.test.communities.gov.uk"
+  load_balancer_domain_name     = local.load_balancer_domain_name
   cloudfront_certificate_arn    = module.certificates.cloudfront_certificate_arn
   load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
   ip_allowlist = [
@@ -93,9 +96,12 @@ module "certificates" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  cloudfront_domain_name      = local.app_host
-  load_balancer_domain_name   = local.load_balancer_domain_name
-  cloudfront_additional_names = module.frontdoor.additional_cloudfront_domain_names
+  cloudfront_domain_name    = local.app_host
+  load_balancer_domain_name = local.load_balancer_domain_name
+  cloudfront_additional_names = [
+    local.search_landlord_host,
+    local.check_home_to_rent_host
+  ]
   load_balancer_additional_names = [
     "${local.environment_name}.lb.search-landlord-home-information.test.communities.gov.uk",
     "${local.environment_name}.lb.check-home-to-rent-registration.test.communities.gov.uk"

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -63,8 +63,7 @@ module "frontdoor" {
   public_subnet_ids             = module.networking.public_subnets[*].id
   vpc_id                        = module.networking.vpc.id
   application_port              = local.application_port
-  cloudfront_domain_name        = local.app_host
-  cloudfront_domain_aliases     = [
+  cloudfront_domain_names     = [
     local.app_host,
     local.search_landlord_host,
     local.check_home_to_rent_host

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -58,12 +58,12 @@ module "frontdoor" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  ssl_certs_created             = var.ssl_certs_created
-  environment_name              = local.environment_name
-  public_subnet_ids             = module.networking.public_subnets[*].id
-  vpc_id                        = module.networking.vpc.id
-  application_port              = local.application_port
-  cloudfront_domain_names     = [
+  ssl_certs_created = var.ssl_certs_created
+  environment_name  = local.environment_name
+  public_subnet_ids = module.networking.public_subnets[*].id
+  vpc_id            = module.networking.vpc.id
+  application_port  = local.application_port
+  cloudfront_domain_names = [
     local.app_host,
     local.search_landlord_host,
     local.check_home_to_rent_host

--- a/terraform/modules/frontdoor/cloudfront.tf
+++ b/terraform/modules/frontdoor/cloudfront.tf
@@ -4,7 +4,7 @@ locals {
 
 #tfsec:ignore:aws-cloudfront-enable-logging: TODO we will be implementing logging later
 resource "aws_cloudfront_distribution" "main" {
-  aliases         = var.ssl_certs_created ? [var.cloudfront_domain_name] : []
+  aliases         = var.ssl_certs_created ? concat([var.cloudfront_domain_name], var.additional_cloudfront_domain_names) : []
   enabled         = true
   http_version    = "http2and3"
   is_ipv6_enabled = true

--- a/terraform/modules/frontdoor/cloudfront.tf
+++ b/terraform/modules/frontdoor/cloudfront.tf
@@ -4,7 +4,7 @@ locals {
 
 #tfsec:ignore:aws-cloudfront-enable-logging: TODO we will be implementing logging later
 resource "aws_cloudfront_distribution" "main" {
-  aliases         = var.ssl_certs_created ? concat([var.cloudfront_domain_name], var.additional_cloudfront_domain_names) : []
+  aliases         = var.ssl_certs_created ? cloudfront_domain_aliases : []
   enabled         = true
   http_version    = "http2and3"
   is_ipv6_enabled = true

--- a/terraform/modules/frontdoor/cloudfront.tf
+++ b/terraform/modules/frontdoor/cloudfront.tf
@@ -4,7 +4,7 @@ locals {
 
 #tfsec:ignore:aws-cloudfront-enable-logging: TODO we will be implementing logging later
 resource "aws_cloudfront_distribution" "main" {
-  aliases         = var.ssl_certs_created ? cloudfront_domain_aliases : []
+  aliases         = var.ssl_certs_created ? var.cloudfront_domain_names : []
   enabled         = true
   http_version    = "http2and3"
   is_ipv6_enabled = true

--- a/terraform/modules/frontdoor/outputs.tf
+++ b/terraform/modules/frontdoor/outputs.tf
@@ -14,3 +14,8 @@ output "cloudfront_dns_name" {
   description = "The domain name of the cloudfront distribution"
   value       = aws_cloudfront_distribution.main.domain_name
 }
+
+output "additional_cloudfront_domain_names" {
+  value       = var.additional_cloudfront_domain_names
+  description = "Additional domain names for the CloudFront distribution"
+}

--- a/terraform/modules/frontdoor/outputs.tf
+++ b/terraform/modules/frontdoor/outputs.tf
@@ -14,8 +14,3 @@ output "cloudfront_dns_name" {
   description = "The domain name of the cloudfront distribution"
   value       = aws_cloudfront_distribution.main.domain_name
 }
-
-output "additional_cloudfront_domain_names" {
-  value       = var.additional_cloudfront_domain_names
-  description = "Additional domain names for the CloudFront distribution"
-}

--- a/terraform/modules/frontdoor/variables.tf
+++ b/terraform/modules/frontdoor/variables.tf
@@ -45,12 +45,7 @@ variable "application_port" {
 #   description = "The id of the ecs security group for ecs egress"
 # }
 
-variable "cloudfront_domain_name" {
-  type        = string
-  description = "MHCLG delegated domain name for cloudfront"
-}
-
-variable "cloudfront_domain_aliases" {
+variable "cloudfront_domain_names" {
   type        = list(string)
   description = "All MHCLG delegated domain names for cloudfront"
 }

--- a/terraform/modules/frontdoor/variables.tf
+++ b/terraform/modules/frontdoor/variables.tf
@@ -50,9 +50,9 @@ variable "cloudfront_domain_name" {
   description = "MHCLG delegated domain name for cloudfront"
 }
 
-variable "additional_cloudfront_domain_names" {
+variable "cloudfront_domain_aliases" {
   type        = list(string)
-  description = "Additional MHCLG delegated domain names for cloudfront"
+  description = "All MHCLG delegated domain names for cloudfront"
 }
 
 variable "load_balancer_domain_name" {

--- a/terraform/modules/frontdoor/variables.tf
+++ b/terraform/modules/frontdoor/variables.tf
@@ -50,6 +50,11 @@ variable "cloudfront_domain_name" {
   description = "MHCLG delegated domain name for cloudfront"
 }
 
+variable "additional_cloudfront_domain_names" {
+  type        = list(string)
+  description = "Additional MHCLG delegated domain names for cloudfront"
+}
+
 variable "load_balancer_domain_name" {
   type        = string
   description = "MHCLG delegated domain name for alb"

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -56,12 +56,16 @@ module "frontdoor" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  ssl_certs_created             = var.ssl_certs_created
-  environment_name              = local.environment_name
-  public_subnet_ids             = module.networking.public_subnets[*].id
-  vpc_id                        = module.networking.vpc.id
-  application_port              = local.application_port
-  cloudfront_domain_name        = "${local.environment_name}.register-home-to-rent.test.communities.gov.uk"
+  ssl_certs_created      = var.ssl_certs_created
+  environment_name       = local.environment_name
+  public_subnet_ids      = module.networking.public_subnets[*].id
+  vpc_id                 = module.networking.vpc.id
+  application_port       = local.application_port
+  cloudfront_domain_name = "${local.environment_name}.register-home-to-rent.test.communities.gov.uk"
+  additional_cloudfront_domain_names = [
+    "${local.environment_name}.search-landlord-home-information.test.communities.gov.uk",
+    "${local.environment_name}.check-home-to-rent-registration.test.communities.gov.uk"
+  ]
   load_balancer_domain_name     = "${local.environment_name}.lb.register-home-to-rent.test.communities.gov.uk"
   cloudfront_certificate_arn    = module.certificates.cloudfront_certificate_arn
   load_balancer_certificate_arn = module.certificates.load_balancer_certificate_arn
@@ -89,12 +93,9 @@ module "certificates" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  cloudfront_domain_name    = local.app_host
-  load_balancer_domain_name = local.load_balancer_domain_name
-  cloudfront_additional_names = [
-    "${local.environment_name}.search-landlord-home-information.test.communities.gov.uk",
-    "${local.environment_name}.check-home-to-rent-registration.test.communities.gov.uk"
-  ]
+  cloudfront_domain_name      = local.app_host
+  load_balancer_domain_name   = local.load_balancer_domain_name
+  cloudfront_additional_names = module.frontdoor.additional_cloudfront_domain_names
   load_balancer_additional_names = [
     "${local.environment_name}.lb.search-landlord-home-information.test.communities.gov.uk",
     "${local.environment_name}.lb.check-home-to-rent-registration.test.communities.gov.uk"

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -63,8 +63,7 @@ module "frontdoor" {
   public_subnet_ids             = module.networking.public_subnets[*].id
   vpc_id                        = module.networking.vpc.id
   application_port              = local.application_port
-  cloudfront_domain_name        = "${local.environment_name}.register-home-to-rent.test.communities.gov.uk"
-  cloudfront_domain_aliases     = [
+  cloudfront_domain_names     = [
     local.app_host,
     local.search_landlord_host,
     local.check_home_to_rent_host

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -58,12 +58,12 @@ module "frontdoor" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  ssl_certs_created             = var.ssl_certs_created
-  environment_name              = local.environment_name
-  public_subnet_ids             = module.networking.public_subnets[*].id
-  vpc_id                        = module.networking.vpc.id
-  application_port              = local.application_port
-  cloudfront_domain_names     = [
+  ssl_certs_created = var.ssl_certs_created
+  environment_name  = local.environment_name
+  public_subnet_ids = module.networking.public_subnets[*].id
+  vpc_id            = module.networking.vpc.id
+  application_port  = local.application_port
+  cloudfront_domain_names = [
     local.app_host,
     local.search_landlord_host,
     local.check_home_to_rent_host

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -34,6 +34,8 @@ locals {
   redis_port       = 6379
 
   app_host                  = "${local.environment_name}.register-home-to-rent.test.communities.gov.uk"
+  search_landlord_host      = "${local.environment_name}.search-landlord-home-information.test.communities.gov.uk"
+  check_home_to_rent_host   = "${local.environment_name}.check-home-to-rent-registration.test.communities.gov.uk"
   load_balancer_domain_name = "${local.environment_name}.lb.register-home-to-rent.test.communities.gov.uk"
 
   cloudwatch_log_expiration_days = 60
@@ -56,15 +58,16 @@ module "frontdoor" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  ssl_certs_created      = var.ssl_certs_created
-  environment_name       = local.environment_name
-  public_subnet_ids      = module.networking.public_subnets[*].id
-  vpc_id                 = module.networking.vpc.id
-  application_port       = local.application_port
-  cloudfront_domain_name = "${local.environment_name}.register-home-to-rent.test.communities.gov.uk"
-  additional_cloudfront_domain_names = [
-    "${local.environment_name}.search-landlord-home-information.test.communities.gov.uk",
-    "${local.environment_name}.check-home-to-rent-registration.test.communities.gov.uk"
+  ssl_certs_created             = var.ssl_certs_created
+  environment_name              = local.environment_name
+  public_subnet_ids             = module.networking.public_subnets[*].id
+  vpc_id                        = module.networking.vpc.id
+  application_port              = local.application_port
+  cloudfront_domain_name        = "${local.environment_name}.register-home-to-rent.test.communities.gov.uk"
+  cloudfront_domain_aliases     = [
+    local.app_host,
+    local.search_landlord_host,
+    local.check_home_to_rent_host
   ]
   load_balancer_domain_name     = "${local.environment_name}.lb.register-home-to-rent.test.communities.gov.uk"
   cloudfront_certificate_arn    = module.certificates.cloudfront_certificate_arn
@@ -93,9 +96,12 @@ module "certificates" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  cloudfront_domain_name      = local.app_host
-  load_balancer_domain_name   = local.load_balancer_domain_name
-  cloudfront_additional_names = module.frontdoor.additional_cloudfront_domain_names
+  cloudfront_domain_name    = local.app_host
+  load_balancer_domain_name = local.load_balancer_domain_name
+  cloudfront_additional_names = [
+    local.search_landlord_host,
+    local.check_home_to_rent_host
+  ]
   load_balancer_additional_names = [
     "${local.environment_name}.lb.search-landlord-home-information.test.communities.gov.uk",
     "${local.environment_name}.lb.check-home-to-rent-registration.test.communities.gov.uk"


### PR DESCRIPTION
- Updated the value passed to cloudfront aliases to be a list including all three of our domain names
- Define the domain names as locals and use these when setting values for frontdoor and certificates