### PR TITLE
PRSD-1282: Fix input template

### DIFF
--- a/terraform/modules/file_upload/virus_scanning.tf
+++ b/terraform/modules/file_upload/virus_scanning.tf
@@ -192,22 +192,25 @@ resource "aws_cloudwatch_event_target" "process_scan_complete_event_target" {
     input_paths = {
       "scanResultDetail" = "$.detail"
     }
-    input_template = jsonencode({
-      containerOverrides = [
+    input_template = <<INPUT_TEMPLATE
+{
+  "containerOverrides": [
+    {
+      "name": "prsdb-webapp",
+      "environment": [
         {
-          name = "prsdb-webapp",
-          environment = [
-            {
-              name  = "SPRING_PROFILES_ACTIVE"
-              value = "web-server-deactivated,example-scan-processor"
-            },
-            {
-              name = "SCAN_RESULT"
-            value = "<scanResultDetail>", }
-          ]
+          "name": "SPRING_PROFILES_ACTIVE",
+          "value": "web-server-deactivated,example-scan-processor"
+        },
+        {
+          "name": "SCAN_RESULT",
+          "value": <scanResultDetail>
         }
       ]
-    })
+    }
+  ]
+}
+INPUT_TEMPLATE
   }
 }
 


### PR DESCRIPTION
The input template needs to be invalid JSON or it is passed in as a literal - therefore we can't use terraform's `jsonencode` (and the placeholder needs not to be in quotes).