### PR TITLE
PRSD-1294: Re-name main function to "handler"

### DIFF
--- a/terraform/modules/frontdoor/url_rewriter.js
+++ b/terraform/modules/frontdoor/url_rewriter.js
@@ -1,4 +1,4 @@
-function url_rewriter(event) {
+function handler(event) {
     const exceptions = ["signout","confirm-sign-out", "error", "assets"];
     const request = event.request;
     let pathSegments = request.uri.split('/');


### PR DESCRIPTION
If I try and test the deployed function I'm getting "The CloudFront function associated with the CloudFront distribution is invalid or could not run. Entry point function "handler" is not found"

So maybe it _has_ to be called handler...