### PR TITLE
PRSD-1294: Update url_rewriter to use the domain from the host name

### DIFF
--- a/terraform/modules/frontdoor/url_rewriter.js
+++ b/terraform/modules/frontdoor/url_rewriter.js
@@ -1,50 +1,32 @@
 function handler(event) {
     const exceptions = ["signout","confirm-sign-out", "error", "assets"];
     const request = event.request;
+    const hostName = request.headers.host.value;
     let pathSegments = request.uri.split('/');
 
-    let domainSegmentIndex;
-    try {
-        // Throws an error if ".gov.uk" is not found in the path segments - we expect this in the domain.
-        domainSegmentIndex = get_domain_segment_index(pathSegments)
-    } catch (error) {
-        // Logs the error and returns the request. If the error was uncaught, the client would see a 500 error.
-        console.log(`Error: ${error.message} for request URI: ${request.uri}`);
+    if (!url_should_be_rewritten(pathSegments, hostName, exceptions)) {
         return request;
     }
 
-    if (!url_should_be_rewritten(pathSegments, domainSegmentIndex, exceptions)) {
-        return request;
-    }
-
-    pathSegments = insert_service_segment_for_domain(pathSegments, domainSegmentIndex);
+    pathSegments = insert_service_segment_for_domain(pathSegments, hostName);
 
     request.uri = pathSegments.join('/');
     return request
 }
 
-function insert_service_segment_for_domain(pathSegments, domainSegmentIndex) {
-    if (pathSegments[domainSegmentIndex].includes("register-home-to-rent")) {
-        pathSegments.splice(domainSegmentIndex+1,0,"landlord");
+function insert_service_segment_for_domain(pathSegments, hostName) {
+    if (hostName.includes("register-home-to-rent")) {
+        pathSegments.splice(1,0,"landlord");
     }
 
-    if (pathSegments[domainSegmentIndex].includes("search-landlord-home-information")) {
-        pathSegments.splice(domainSegmentIndex+1,0,"local-authority");
+    if (hostName.includes("search-landlord-home-information")) {
+        pathSegments.splice(1,0,"local-authority");
     }
     return pathSegments;
 }
 
-function get_domain_segment_index(pathSegments) {
-    const domainSegmentIndex = pathSegments.findIndex(segment => segment.includes(".gov.uk"));
-    if (domainSegmentIndex === -1) {
-        // If no domain segment is found, return the request as is
-        throw new Error(".gov.uk domain segment not found in the request URI");
-    }
-    return domainSegmentIndex;
-}
-
-function url_should_be_rewritten(pathSegments, domainSegmentIndex, exceptions) {
-    return !(exceptions.includes(pathSegments[domainSegmentIndex + 1]) ||
-        (pathSegments[domainSegmentIndex].includes("register-home-to-rent") && pathSegments[domainSegmentIndex + 1] === "landlord") ||
-        (pathSegments[domainSegmentIndex].includes("search-landlord-home-information") && pathSegments[domainSegmentIndex + 1] === "local-authority"));
+function url_should_be_rewritten(pathSegments, hostName, exceptions) {
+    return !(exceptions.includes(pathSegments[1]) ||
+        (hostName.includes("register-home-to-rent") && pathSegments[1] === "landlord") ||
+        (hostName.includes("search-landlord-home-information") && pathSegments[1] === "local-authority"));
 }


### PR DESCRIPTION
Updates the url_rewriter for the actual request structure.

The domain is not included in request.uri, but is instead in request.headers.host.value

So we are always looking to insert the service name in the first path segment (after the first '/')