### PR TITLE
PRSD-1283: Add additional permissions to service for s3

### DIFF
--- a/terraform/modules/file_upload/quarantine_bucket.tf
+++ b/terraform/modules/file_upload/quarantine_bucket.tf
@@ -23,6 +23,9 @@ data "aws_iam_policy_document" "upload_to_quarantine" {
     sid = "QuarantineS3"
     actions = [
       "s3:PutObject",
+      "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:DeleteObject",
     ]
     resources = [
       "${module.quarantine_bucket.bucket_arn}/*",

--- a/terraform/modules/file_upload/safe_bucket.tf
+++ b/terraform/modules/file_upload/safe_bucket.tf
@@ -23,6 +23,7 @@ data "aws_iam_policy_document" "upload_to_safe" {
     sid = "SafeS3"
     actions = [
       "s3:PutObject",
+      "s3:PutObjectTagging",
     ]
     resources = [
       "${module.uploaded_files_bucket.bucket_arn}/*",


### PR DESCRIPTION
Adds the necessary permissions to copy a tagged object from the quarantine bucket to the safe bucket for the ecs task.