### PR TITLE
PRSD-1167: Makes the cookies page endpoint reachable

### DIFF
--- a/terraform/modules/frontdoor/url_rewriter.js
+++ b/terraform/modules/frontdoor/url_rewriter.js
@@ -1,5 +1,5 @@
 function handler(event) {
-    const exceptions = ["signout","confirm-sign-out", "error", "assets", "id-verification", "logout", "oauth2", "healthcheck"];
+    const exceptions = ["signout","confirm-sign-out", "error", "assets", "id-verification", "logout", "oauth2", "healthcheck", "cookies"];
     const request = event.request;
     const hostName = request.headers.host.value;
     let pathSegments = request.uri.split('/');

--- a/test/js/url_rewriter.test.js
+++ b/test/js/url_rewriter.test.js
@@ -146,6 +146,17 @@ describe('url_rewriter', () => {
             // then
             expect(new_event.headers.host.value + new_event.uri).toBe('https://register-home-to-rent.communities.gov.uk/healthcheck');
         });
+
+        it('returns the original url for the /cookies endpoint', () => {
+            // given
+            const event = createRequestEvent(registerHomeToRentHost, '/cookies');
+
+            // when
+            const new_event = url_rewriter(event);
+
+            // then
+            expect(new_event.headers.host.value + new_event.uri).toBe('https://register-home-to-rent.communities.gov.uk/cookies');
+        });
     });
 
     describe('for the search-landlord-home-information domain', () => {
@@ -280,6 +291,17 @@ describe('url_rewriter', () => {
 
             // then
             expect(new_event.headers.host.value + new_event.uri).toBe('https://search-landlord-home-information.communities.gov.uk/healthcheck');
+        });
+
+        it('returns the original url for the /cookies endpoint', () => {
+            // given
+            const event = createRequestEvent(searchLandlordHomeInformationHost, '/cookies');
+
+            // when
+            const new_event = url_rewriter(event);
+
+            // then
+            expect(new_event.headers.host.value + new_event.uri).toBe('https://search-landlord-home-information.communities.gov.uk/cookies');
         });
     });
 });


### PR DESCRIPTION
## Ticket number

PRSD-1167

## Goal of change

Make the cookies page endpoint reachable by making it exempt from URL rewriting

## Description of main change(s)

- Adds the cookies page to the array of endpoints exempt from URL rewriting 

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist
Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done