### PR TITLE
PRSD-1355: update urls to be local council instead of local authority

### DIFF
--- a/terraform/modules/frontdoor/UrlRewriterReadMe.md
+++ b/terraform/modules/frontdoor/UrlRewriterReadMe.md
@@ -1,6 +1,6 @@
 # URL Rewriter
 
-url_writer is a cloudfront function that inserts a service path segment (i.e. `/landlord` or `/local-authority`) into the request URL.
+url_writer is a cloudfront function that inserts a service path segment (i.e. `/landlord` or `/local-council`) into the request URL.
 
 ## Excluded endpoints
 Endpoints which are common between services such as `/error` and `/signout` are excluded from the rewriting, so do not include the service name.

--- a/terraform/modules/frontdoor/url_rewriter.js
+++ b/terraform/modules/frontdoor/url_rewriter.js
@@ -20,7 +20,7 @@ function insert_service_segment_for_domain(pathSegments, hostName) {
     }
 
     if (hostName.includes("search-landlord-home-information")) {
-        pathSegments.splice(1,0,"local-authority");
+        pathSegments.splice(1,0,"local-council");
     }
     return pathSegments;
 }
@@ -28,5 +28,5 @@ function insert_service_segment_for_domain(pathSegments, hostName) {
 function url_should_be_rewritten(pathSegments, hostName, exceptions) {
     return !(exceptions.includes(pathSegments[1]) ||
         (hostName.includes("register-home-to-rent") && pathSegments[1] === "landlord") ||
-        (hostName.includes("search-landlord-home-information") && pathSegments[1] === "local-authority"));
+        (hostName.includes("search-landlord-home-information") && pathSegments[1] === "local-council"));
 }

--- a/test/js/url_rewriter.test.js
+++ b/test/js/url_rewriter.test.js
@@ -48,15 +48,15 @@ describe('url_rewriter', () => {
 
         })
 
-        it('inserts /landlord into a URL where the first path segment is /local-authority', () => {
+        it('inserts /landlord into a URL where the first path segment is /local-council', () => {
             // given
-            const event = createRequestEvent(registerHomeToRentHost, '/local-authority/dashboard');
+            const event = createRequestEvent(registerHomeToRentHost, '/local-council/dashboard');
 
             // when
             const new_event = url_rewriter(event);
 
             // then
-            expect(new_event.headers.host.value + new_event.uri).toBe('https://register-home-to-rent.communities.gov.uk/landlord/local-authority/dashboard');
+            expect(new_event.headers.host.value + new_event.uri).toBe('https://register-home-to-rent.communities.gov.uk/landlord/local-council/dashboard');
         });
 
         it('returns the original url for the /signout endpoint', () => {
@@ -160,7 +160,7 @@ describe('url_rewriter', () => {
     });
 
     describe('for the search-landlord-home-information domain', () => {
-        it('inserts /local-authority into the dashboard URL', () => {
+        it('inserts /local-council into the dashboard URL', () => {
             // given
             const event = createRequestEvent(searchLandlordHomeInformationHost, '/dashboard');
 
@@ -168,33 +168,33 @@ describe('url_rewriter', () => {
             const new_event = url_rewriter(event);
 
             // then
-            expect(new_event.headers.host.value + new_event.uri).toBe('https://search-landlord-home-information.communities.gov.uk/local-authority/dashboard');
+            expect(new_event.headers.host.value + new_event.uri).toBe('https://search-landlord-home-information.communities.gov.uk/local-council/dashboard');
         });
 
-        it('returns the original url if the first path segment after the domain is already /local-authority', () => {
+        it('returns the original url if the first path segment after the domain is already /local-council', () => {
             // given
-            const event = createRequestEvent(searchLandlordHomeInformationHost, '/local-authority/dashboard');
+            const event = createRequestEvent(searchLandlordHomeInformationHost, '/local-council/dashboard');
 
             // when
             const new_event = url_rewriter(event);
 
             // then
-            expect(new_event.headers.host.value + new_event.uri).toBe('https://search-landlord-home-information.communities.gov.uk/local-authority/dashboard');
+            expect(new_event.headers.host.value + new_event.uri).toBe('https://search-landlord-home-information.communities.gov.uk/local-council/dashboard');
         });
 
-        it('inserts /local-authority into a URL which has a /local-authority segment, but not as the first path segment', () => {
+        it('inserts /local-council into a URL which has a /local-council segment, but not as the first path segment', () => {
             // given
-            const event = createRequestEvent(searchLandlordHomeInformationHost, '/dashboard/local-authority');
+            const event = createRequestEvent(searchLandlordHomeInformationHost, '/dashboard/local-council');
 
             // when
             const new_event = url_rewriter(event);
 
             // then
-            expect(new_event.headers.host.value + new_event.uri).toBe('https://search-landlord-home-information.communities.gov.uk/local-authority/dashboard/local-authority');
+            expect(new_event.headers.host.value + new_event.uri).toBe('https://search-landlord-home-information.communities.gov.uk/local-council/dashboard/local-council');
 
         })
 
-        it('inserts /local-authority into a URL where the first path segment is /landlord', () => {
+        it('inserts /local-council into a URL where the first path segment is /landlord', () => {
             // given
             const event = createRequestEvent(searchLandlordHomeInformationHost, '/landlord/dashboard');
 
@@ -202,7 +202,7 @@ describe('url_rewriter', () => {
             const new_event = url_rewriter(event);
 
             // then
-            expect(new_event.headers.host.value + new_event.uri).toBe('https://search-landlord-home-information.communities.gov.uk/local-authority/landlord/dashboard');
+            expect(new_event.headers.host.value + new_event.uri).toBe('https://search-landlord-home-information.communities.gov.uk/local-council/landlord/dashboard');
         });
 
         it('returns the original url for the /signout endpoint', () => {


### PR DESCRIPTION
## Ticket number

PRSD-1355

## Goal of change

Update urls to be local council instead of local authority

## Description of main change(s)

Update url_rewriter.js to use "local-council" instead of "local-authority"
Updated tests

## Anything you'd like to highlight to the reviewer?

This PR should be merged at the same time or just after the equivalent webapp PR (not yet created)

## Checklist

N/A