### PR TITLE
PRSD-1183: Add environment variables for analytics domain ids

### DIFF
--- a/terraform/environment_template/ecs_task_definition/data.tf.template
+++ b/terraform/environment_template/ecs_task_definition/data.tf.template
@@ -89,3 +89,15 @@ data "aws_ssm_parameter" "landlord_base_url" {
 data "aws_ssm_parameter" "local_authority_base_url" {
   name = "${local.environment_name}-prsdb-local-authority-base-url"
 }
+
+data "aws_ssm_parameter" "plausible_analytics_domain_id" {
+  name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
+}
+
+data "aws_ssm_parameter" "google_analytics_measurement_id" {
+  name = "${local.environment_name}-prsdb-google-analytics-measurement-id"
+}
+
+data "aws_ssm_parameter" "google_analytics_cookie_domain" {
+  name = "${local.environment_name}-prsdb-google-analytics-cookie-domain"
+}

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -90,7 +90,19 @@ locals {
     {
       name = "LOCAL_AUTHORITY_BASE_URL"
       value = data.aws_ssm_parameter.local_authority_base_url.value
-    }
+    },
+    {
+      name = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
+      value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
+    },
+    {
+      name = "GOOGLE_ANALYTICS_MEASUREMENT_ID"
+      value = data.aws_ssm_parameter.google_analytics_measurement_id.value
+    },
+    {
+      name = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
+      value = data.aws_ssm_parameter.google_analytics_cookie_domain.value
+    },
   ]
   secrets = [
     {

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -89,3 +89,15 @@ data "aws_ssm_parameter" "landlord_base_url" {
 data "aws_ssm_parameter" "local_authority_base_url" {
   name = "${local.environment_name}-prsdb-local-authority-base-url"
 }
+
+data "aws_ssm_parameter" "plausible_analytics_domain_id" {
+  name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
+}
+
+data "aws_ssm_parameter" "google_analytics_measurement_id" {
+  name = "${local.environment_name}-prsdb-google-analytics-measurement-id"
+}
+
+data "aws_ssm_parameter" "google_analytics_cookie_domain" {
+  name = "${local.environment_name}-prsdb-google-analytics-cookie-domain"
+}

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -92,15 +92,15 @@ locals {
       value = data.aws_ssm_parameter.local_authority_base_url.value
     },
     {
-      name = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
+      name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
       value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
     },
     {
-      name = "GOOGLE_ANALYTICS_MEASUREMENT_ID"
+      name  = "GOOGLE_ANALYTICS_MEASUREMENT_ID"
       value = data.aws_ssm_parameter.google_analytics_measurement_id.value
     },
     {
-      name = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
+      name  = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
       value = data.aws_ssm_parameter.google_analytics_cookie_domain.value
     },
   ]

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -90,7 +90,19 @@ locals {
     {
       name  = "LOCAL_AUTHORITY_BASE_URL"
       value = data.aws_ssm_parameter.local_authority_base_url.value
-    }
+    },
+    {
+      name = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
+      value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
+    },
+    {
+      name = "GOOGLE_ANALYTICS_MEASUREMENT_ID"
+      value = data.aws_ssm_parameter.google_analytics_measurement_id.value
+    },
+    {
+      name = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
+      value = data.aws_ssm_parameter.google_analytics_cookie_domain.value
+    },
   ]
   secrets = [
     {

--- a/terraform/modules/ssm/parameters.tf
+++ b/terraform/modules/ssm/parameters.tf
@@ -81,3 +81,33 @@ resource "aws_ssm_parameter" "local_authority_base_url" {
   type  = "String"
   value = var.local_authority_base_url
 }
+
+resource "aws_ssm_parameter" "plausible_analytics_domain_id" {
+  name  = "${var.environment_name}-prsdb-plausible-analytics-domain-id"
+  type  = "String"
+  value = "default_to_be_set_manually" # To be set manually on AWS
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_ssm_parameter" "google_analytics_measurement_id" {
+  name  = "${var.environment_name}-prsdb-google-analytics-measurement-id"
+  type  = "String"
+  value = "default_to_be_set_manually" # To be set manually on AWS
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_ssm_parameter" "google_analytics_cookie_domain" {
+  name  = "${var.environment_name}-prsdb-google-analytics-cookie-domain"
+  type  = "String"
+  value = "default_to_be_set_manually" # To be set manually on AWS
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -89,3 +89,15 @@ data "aws_ssm_parameter" "landlord_base_url" {
 data "aws_ssm_parameter" "local_authority_base_url" {
   name = "${local.environment_name}-prsdb-local-authority-base-url"
 }
+
+data "aws_ssm_parameter" "plausible_analytics_domain_id" {
+  name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
+}
+
+data "aws_ssm_parameter" "google_analytics_measurement_id" {
+  name = "${local.environment_name}-prsdb-google-analytics-measurement-id"
+}
+
+data "aws_ssm_parameter" "google_analytics_cookie_domain" {
+  name = "${local.environment_name}-prsdb-google-analytics-cookie-domain"
+}

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -92,15 +92,15 @@ locals {
       value = data.aws_ssm_parameter.local_authority_base_url.value
     },
     {
-      name = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
+      name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
       value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
     },
     {
-      name = "GOOGLE_ANALYTICS_MEASUREMENT_ID"
+      name  = "GOOGLE_ANALYTICS_MEASUREMENT_ID"
       value = data.aws_ssm_parameter.google_analytics_measurement_id.value
     },
     {
-      name = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
+      name  = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
       value = data.aws_ssm_parameter.google_analytics_cookie_domain.value
     },
   ]

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -90,7 +90,19 @@ locals {
     {
       name  = "LOCAL_AUTHORITY_BASE_URL"
       value = data.aws_ssm_parameter.local_authority_base_url.value
-    }
+    },
+    {
+      name = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
+      value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
+    },
+    {
+      name = "GOOGLE_ANALYTICS_MEASUREMENT_ID"
+      value = data.aws_ssm_parameter.google_analytics_measurement_id.value
+    },
+    {
+      name = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
+      value = data.aws_ssm_parameter.google_analytics_cookie_domain.value
+    },
   ]
   secrets = [
     {


### PR DESCRIPTION
## Ticket number

PRSD-1183

## Goal of change

Pass in analytics ids as environment variables so we can use a different id for prod when it comes

## Description of main change(s)

Added
- plausible analytics domain id
- google analytics measurement id
- google analytics cookie domain (we need this to delete cookies if a user changes their preferences to reject cookies)

## Anything you'd like to highlight to the reviewer?

## Checklist

- [ ] Any special release instructions (e.g. set environment variables) have been added as checklist items to a draft PR (merging `main` into `test`) for the next release.

  Make sure to include details such as the name of the variable, where it needs to be set (e.g. AWS Secrets Manager or Parameter Store), and what it should be set to (this might be a location in keeper where a secret value can be found)