### PR TITLE
PRSD-1166: Adds require-passcode to Active Profiles

### DIFF
--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -103,6 +103,10 @@ locals {
       name = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
       value = data.aws_ssm_parameter.google_analytics_cookie_domain.value
     },
+    {
+      name  = "SPRING_PROFILES_ACTIVE"
+      value = "require-passcode"
+    },
   ]
   secrets = [
     {

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -103,6 +103,10 @@ locals {
       name  = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
       value = data.aws_ssm_parameter.google_analytics_cookie_domain.value
     },
+    {
+      name  = "SPRING_PROFILES_ACTIVE"
+      value = "require-passcode"
+    },
   ]
   secrets = [
     {

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -103,6 +103,10 @@ locals {
       name  = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
       value = data.aws_ssm_parameter.google_analytics_cookie_domain.value
     },
+    {
+      name  = "SPRING_PROFILES_ACTIVE"
+      value = "require-passcode"
+    },
   ]
   secrets = [
     {


### PR DESCRIPTION
## Ticket number

PRSD-1166

## Goal of change

Adds require-passcode to active spring profiles in integration and test environments

## Description of main change(s)

- Updates ECS task definition's integration and test environment variables to include require-passcode as an active spring profile

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist
Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done