### PR TITLE
PRSD-1166: Keep default profile when require-passcode is active

### DIFF
--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -105,7 +105,7 @@ locals {
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"
-      value = "require-passcode"
+      value = "default,require-passcode"
     },
     {
       name  = "EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY"

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -105,7 +105,7 @@ locals {
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"
-      value = "require-passcode"
+      value = "default,require-passcode"
     },
     {
       name  = "EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY"

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -105,7 +105,7 @@ locals {
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"
-      value = "require-passcode"
+      value = "default,require-passcode"
     },
     {
       name  = "EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY"


### PR DESCRIPTION
## Ticket number

PRSD-1166

## Goal of change

Ensures default profile is used when require-passcode is active

## Description of main change(s)

- Adds default to active spring profiles where require-passcode is

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist
Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done