### PR TITLE
PRSD-NONE: Adds environment variable for One Login DID URL

### DIFF
--- a/terraform/environment_template/ecs_task_definition/data.tf.template
+++ b/terraform/environment_template/ecs_task_definition/data.tf.template
@@ -18,6 +18,10 @@ data "aws_ssm_parameter" "one_login_issuer_url" {
   name = "${local.environment_name}-one-login-issuer-url"
 }
 
+data "aws_ssm_parameter" "one_login_did_url" {
+    name = "${local.environment_name}-one-login-did-url"
+}
+
 data "aws_ssm_parameter" "database_username" {
   name = "${local.environment_name}-prsdb-database-username"
 }

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -44,6 +44,10 @@ locals {
       value = data.aws_ssm_parameter.one_login_issuer_url.value
     },
     {
+      name = "ONE_LOGIN_DID_URL"
+      value = data.aws_ssm_parameter.one_login_did_url.value
+    },
+    {
       name  = "RDS_URL"
       value = "jdbc:postgresql://${data.aws_ssm_parameter.database_url.value}"
     },

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -18,6 +18,10 @@ data "aws_ssm_parameter" "one_login_issuer_url" {
   name = "${local.environment_name}-one-login-issuer-url"
 }
 
+data "aws_ssm_parameter" "one_login_did_url" {
+  name = "${local.environment_name}-one-login-did-url"
+}
+
 data "aws_ssm_parameter" "database_username" {
   name = "${local.environment_name}-prsdb-database-username"
 }

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -44,6 +44,10 @@ locals {
       value = data.aws_ssm_parameter.one_login_issuer_url.value
     },
     {
+      name  = "ONE_LOGIN_DID_URL"
+      value = data.aws_ssm_parameter.one_login_did_url.value
+    },
+    {
       name  = "RDS_URL"
       value = "jdbc:postgresql://${data.aws_ssm_parameter.database_url.value}"
     },

--- a/terraform/modules/ssm/parameters.tf
+++ b/terraform/modules/ssm/parameters.tf
@@ -30,6 +30,16 @@ resource "aws_ssm_parameter" "one_login_issuer_url" {
   }
 }
 
+resource "aws_ssm_parameter" "one_login_did_url" {
+  name  = "${var.environment_name}-one-login-did-url"
+  type  = "String"
+  value = "default_to_be_set_manually" # To be set manually on AWS
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
 resource "aws_ssm_parameter" "epc_register_client_id" {
   name  = "${var.environment_name}-prsdb-epc-client-id"
   type  = "String"

--- a/terraform/production/ecs_task_definition/data.tf
+++ b/terraform/production/ecs_task_definition/data.tf
@@ -18,6 +18,10 @@ data "aws_ssm_parameter" "one_login_issuer_url" {
   name = "${local.environment_name}-one-login-issuer-url"
 }
 
+data "aws_ssm_parameter" "one_login_did_url" {
+  name = "${local.environment_name}-one-login-did-url"
+}
+
 data "aws_ssm_parameter" "database_username" {
   name = "${local.environment_name}-prsdb-database-username"
 }

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -44,6 +44,10 @@ locals {
       value = data.aws_ssm_parameter.one_login_issuer_url.value
     },
     {
+      name  = "ONE_LOGIN_DID_URL"
+      value = data.aws_ssm_parameter.one_login_did_url.value
+    },
+    {
       name  = "RDS_URL"
       value = "jdbc:postgresql://${data.aws_ssm_parameter.database_url.value}"
     },
@@ -103,10 +107,10 @@ locals {
       name  = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
       value = data.aws_ssm_parameter.google_analytics_cookie_domain.value
     },
-    {
-      name  = "SPRING_PROFILES_ACTIVE"
-      value = "default,require-passcode"
-    },
+    # {
+    #   name  = "SPRING_PROFILES_ACTIVE"
+    #   value = "default,require-passcode"
+    # }
     {
       name  = "EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY"
       value = contains(["production"], local.environment_name) ? "true" : "false"

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -18,6 +18,10 @@ data "aws_ssm_parameter" "one_login_issuer_url" {
   name = "${local.environment_name}-one-login-issuer-url"
 }
 
+data "aws_ssm_parameter" "one_login_did_url" {
+  name = "${local.environment_name}-one-login-did-url"
+}
+
 data "aws_ssm_parameter" "database_username" {
   name = "${local.environment_name}-prsdb-database-username"
 }

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -44,6 +44,10 @@ locals {
       value = data.aws_ssm_parameter.one_login_issuer_url.value
     },
     {
+      name  = "ONE_LOGIN_DID_URL"
+      value = data.aws_ssm_parameter.one_login_did_url.value
+    },
+    {
       name  = "RDS_URL"
       value = "jdbc:postgresql://${data.aws_ssm_parameter.database_url.value}"
     },


### PR DESCRIPTION
## Ticket number

PRSD-NONE

## Goal of change

Hotfix to create environment variable for One Login DID URL

## Anything you'd like to highlight to the reviewer?

As we're not yet live this hotifx will go directly to production, and then merged back down production->test, test->main (with normal non-squash merges).

The value will be set in each environment before we roll out the Webapp hotifx that relies on it.

Also temporarily turning off passcodes for convenience until prod is fully smoke tested (have already verified these are working).