### PR TITLE
PRSD-1178: Adds cloudwatch alarm for ConsoleLogin

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -9,6 +9,10 @@ on:
         required: true
         type: string
 
+env:
+  TF_VAR_alarm_email_address: ${{ secrets.ALARMS_EMAIL }}
+
+
 jobs:
   validate-target-environment:
     name: Validate Target Environment

--- a/.github/workflows/check-and-plan.yml
+++ b/.github/workflows/check-and-plan.yml
@@ -9,6 +9,9 @@ on:
         required: true
         type: string
 
+env:
+  TF_VAR_alarm_email_address: ${{ secrets.ALARMS_EMAIL }}
+
 jobs:
   validate-target-environment:
     name: Validate Target Environment

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -222,6 +222,7 @@ Get the One-Login admin to add these for each of the cloudfront domains used abo
 - If the output of the plan looks correct, run `terraform apply` to create the pre-requisite resources.
 - Terraform will create the webapp secrets and SSM parameters but (apart from those related to the database and Redis) will not populate them. Ask the team lead where you can find the appropriate values, and then populate them via the AWS console.
   - For Notify, this will involve creating a new API Key to use for the new environment.
+  - You will also need to add a new environment secret in Github called `ALARMS_EMAIL` with the email address to use for alarms in the new environment.
 - To create the task definition, in `terraform/<environment name>/ecs_task_definition`, if you haven't already, remove the `.template` from the end of any file names in the folder, and replace all instances of the string `<environment name>` with your actual environment name.
 - In `terraform/<environment name>/ecs_task_definition/terraform.tfvars`, set the `file_upload_created` variable to `false`.
 - Next, cd into `terraform/<environment name>/ecs_task_definition` and run `terraform init` followed by `terraform plan`. This should show you one resource being created - the task definition. If the output looks correct, run `terraform apply`.

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -211,3 +211,11 @@ module "file_upload" {
   private_subnet_ids              = module.networking.private_subnets[*].id
   ecs_security_group_ids          = module.ecs_service[0].ecs_security_group_ids
 }
+
+module "monitoring" {
+  source = "../modules/monitoring"
+
+  environment_name               = local.environment_name
+  cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
+  alarm_email_address            = var.alarm_email_address
+}

--- a/terraform/integration/variables.tf
+++ b/terraform/integration/variables.tf
@@ -9,3 +9,9 @@ variable "task_definition_created" {
   type        = bool
   default     = true
 }
+
+variable "alarm_email_address" {
+  description = "Email addresses to receive CloudWatch alarm notifications"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/modules/monitoring/alarms.tf
+++ b/terraform/modules/monitoring/alarms.tf
@@ -1,0 +1,18 @@
+resource "aws_cloudwatch_metric_alarm" "console_login" {
+  alarm_name          = "console-login-${var.environment_name}"
+  alarm_description   = "Someone has logged in to the AWS console"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  metric_name         = aws_cloudwatch_log_metric_filter.console_login.name
+  evaluation_periods  = 1
+  period              = 60
+  threshold           = 1
+  statistic           = "Sum"
+  namespace           = "prsd/${var.environment_name}/security"
+
+  alarm_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+}
+
+

--- a/terraform/modules/monitoring/cloudtrail.tf
+++ b/terraform/modules/monitoring/cloudtrail.tf
@@ -1,0 +1,18 @@
+resource "aws_cloudtrail" "main" {
+  name                          = "prsd-cloudtrail-${var.environment_name}"
+  s3_bucket_name                = module.s3_bucket.bucket
+  include_global_service_events = true
+  is_multi_region_trail         = true
+  cloud_watch_logs_group_arn    = "${module.cloudtrail_cloudwatch_group.log_group_arn}:*"
+  cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail_cloudwatch_role.arn
+}
+
+module "cloudtrail_cloudwatch_group" {
+  source = "../encrypted_log_group"
+
+  log_group_name     = "prsd-cloudtrail-${var.environment_name}"
+  log_retention_days = var.cloudwatch_log_expiration_days
+}
+
+
+

--- a/terraform/modules/monitoring/iam.tf
+++ b/terraform/modules/monitoring/iam.tf
@@ -1,0 +1,74 @@
+data "aws_iam_policy_document" "cloudtrail_cloudwatch_assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}
+
+resource "aws_iam_role" "cloudtrail_cloudwatch_role" {
+  name               = "cloudtrail-cloudwatch-role-${var.environment_name}"
+  assume_role_policy = data.aws_iam_policy_document.cloudtrail_cloudwatch_assume_role.json
+}
+
+data "aws_iam_policy_document" "cloudtrail_cloudwatch_policy_document" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams",
+    ]
+
+    resources = [
+      "${module.cloudtrail_cloudwatch_group.log_group_arn}:*:*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "cloudtrail_cloudwatch_policy" {
+  name   = "cloudtrail-cloudwatch-policy-${var.environment_name}"
+  policy = data.aws_iam_policy_document.cloudtrail_cloudwatch_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "cloudtrail_cloudwatch_policy_attachment" {
+  role       = aws_iam_role.cloudtrail_cloudwatch_role.name
+  policy_arn = aws_iam_policy.cloudtrail_cloudwatch_policy.arn
+}
+
+resource "aws_sns_topic_policy" "cloudwatch_to_alarm_sns" {
+  arn    = aws_sns_topic.alarm_sns_topic.id
+  policy = data.aws_iam_policy_document.cloudwatch_to_sns_policy_document.json
+}
+
+data "aws_iam_policy_document" "cloudwatch_to_sns_policy_document" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sns:Publish"
+    ]
+    resources = [
+      aws_sns_topic.alarm_sns_topic.arn
+    ]
+    principals {
+      type = "Service"
+      identifiers = [
+        "cloudwatch.amazonaws.com"
+      ]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}

--- a/terraform/modules/monitoring/kms.tf
+++ b/terraform/modules/monitoring/kms.tf
@@ -1,0 +1,68 @@
+resource "aws_kms_key" "main" {
+  enable_key_rotation = true
+  description         = "prsdb-cloudtrail-${var.environment_name}"
+}
+
+resource "aws_kms_key_policy" "main" {
+  key_id = aws_kms_key.main.key_id
+  policy = data.aws_iam_policy_document.cloudtrail_kms.json
+}
+
+resource "aws_kms_alias" "main" {
+  name          = "alias/cloudtrail-${var.environment_name}"
+  target_key_id = aws_kms_key.main.key_id
+}
+
+data "aws_iam_policy_document" "cloudtrail_kms" {
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+    }
+
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+
+    resources = ["*"]
+    condition {
+      test     = "ArnLike"
+      variable = "kms:EncryptionContext:aws:logs:arn"
+      values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${module.cloudtrail_cloudwatch_group.name}"]
+    }
+  }
+
+  # Required to allow the KMS key to be managed after creation: https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-root-enable-iam
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+
+    actions = ["kms:*"]
+
+    resources = [aws_kms_key.main.arn]
+  }
+
+  # This statement allows CloudTrail to use the KMS key for encryption
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    actions = ["kms:GenerateDataKey*"]
+
+
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_cloudtrail.main.arn]
+    }
+  }
+}

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = "~>1.9.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>5.0"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}

--- a/terraform/modules/monitoring/metrics.tf
+++ b/terraform/modules/monitoring/metrics.tf
@@ -1,0 +1,13 @@
+resource "aws_cloudwatch_log_metric_filter" "console_login" {
+  log_group_name = module.cloudtrail_cloudwatch_group.name
+  name           = "console_login_${var.environment_name}"
+  pattern        = <<EOT
+    {($.eventName = "ConsoleLogin") && ($.responseElements.ConsoleLogin = "Success")}
+  EOT
+
+  metric_transformation {
+    name      = "console_login_${var.environment_name}"
+    namespace = "prsd/${var.environment_name}/security"
+    value     = "1"
+  }
+}

--- a/terraform/modules/monitoring/s3.tf
+++ b/terraform/modules/monitoring/s3.tf
@@ -1,0 +1,68 @@
+module "s3_bucket" {
+  source = "../s3_bucket"
+
+  access_log_bucket_name             = "prsdb-cloudtrail-${var.environment_name}-access-logs"
+  bucket_name                        = "prsdb-cloudtrail-${var.environment_name}"
+  access_s3_log_expiration_days      = var.cloudwatch_log_expiration_days
+  policy                             = data.aws_iam_policy_document.bucket_policy.json
+  kms_key_arn                        = aws_kms_key.main.arn
+  noncurrent_version_expiration_days = var.cloudwatch_log_expiration_days
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "expire" {
+  bucket = module.s3_bucket.bucket
+
+  rule {
+    id = "expiration"
+    filter {
+      prefix = ""
+    }
+    expiration {
+      days = var.cloudwatch_log_expiration_days
+    }
+    status = "Enabled"
+  }
+}
+
+data "aws_iam_policy_document" "bucket_policy" {
+  statement {
+    sid    = "AWSCloudTrailAclCheck"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    actions   = ["s3:GetBucketAcl"]
+    resources = [module.s3_bucket.bucket_arn]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values = [
+        "arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/prsd-cloudtrail-${var.environment_name}"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "AWSCloudTrailWrite"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    actions   = ["s3:PutObject"]
+    resources = ["${module.s3_bucket.bucket_arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values = [
+        "arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/prsd-cloudtrail-${var.environment_name}"
+      ]
+    }
+  }
+}

--- a/terraform/modules/monitoring/sns.tf
+++ b/terraform/modules/monitoring/sns.tf
@@ -1,0 +1,10 @@
+resource "aws_sns_topic" "alarm_sns_topic" {
+  name         = "${var.environment_name}-alarm-sns-topic"
+  display_name = "Notifications for cloudwatch alarms in ${var.environment_name} environment"
+}
+
+resource "aws_sns_topic_subscription" "alarm_email_subscription" {
+  topic_arn = aws_sns_topic.alarm_sns_topic.arn
+  protocol  = "email"
+  endpoint  = var.alarm_email_address
+}

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -1,0 +1,18 @@
+variable "environment_name" {
+  description = "must be one of: integration, test, nft, or production"
+  type        = string
+  validation {
+    condition     = contains(["integration", "test", "nft", "production"], var.environment_name)
+    error_message = "Environment must be one of: integration, test, nft, or production"
+  }
+}
+
+variable "alarm_email_address" {
+  description = "Email address to receive CloudWatch alarm notifications"
+  type        = string
+}
+
+variable "cloudwatch_log_expiration_days" {
+  type        = number
+  description = "Number of days to retain cloudwatch logs for"
+}

--- a/terraform/modules/networking/vpc_endpoints.tf
+++ b/terraform/modules/networking/vpc_endpoints.tf
@@ -29,6 +29,8 @@ locals {
     "monitoring",
     "logs",
     "s3tables",
+    "cloudtrail",
+    "sns",
   ]
 }
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -207,3 +207,11 @@ module "file_upload" {
   private_subnet_ids              = module.networking.private_subnets[*].id
   ecs_security_group_ids          = module.ecs_service[0].ecs_security_group_ids
 }
+
+module "monitoring" {
+  source = "../modules/monitoring"
+
+  environment_name               = local.environment_name
+  cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
+  alarm_email_address            = var.alarm_email_address
+}

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -9,3 +9,9 @@ variable "task_definition_created" {
   type        = bool
   default     = true
 }
+
+variable "alarm_email_address" {
+  description = "Email addresses to receive CloudWatch alarm notifications"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -211,3 +211,11 @@ module "file_upload" {
   private_subnet_ids              = module.networking.private_subnets[*].id
   ecs_security_group_ids          = module.ecs_service[0].ecs_security_group_ids
 }
+
+module "monitoring" {
+  source = "../modules/monitoring"
+
+  environment_name               = local.environment_name
+  cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
+  alarm_email_address            = var.alarm_slack_email_address
+}

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -9,3 +9,9 @@ variable "task_definition_created" {
   type        = bool
   default     = true
 }
+
+variable "alarm_slack_email_address" {
+  description = "Email addresses to receive CloudWatch alarm notifications"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Ticket number

PRSD-1178

## Goal of change

Adds cloudwatch alarm for users logging into the AWS console. The notification is sent to an email addresse determined by a secret in github (these have already been added for all environments).

## Description of main change(s)

Adds monitoring module, which includes Cloudtrail + accomanying log group, s3 bucket IAM policies etc as well as the Cloudwatch metric and the alarm itself
