### PR TITLE
PRSD-1178: Removes circular dependency in kms policy

### DIFF
--- a/terraform/modules/monitoring/kms.tf
+++ b/terraform/modules/monitoring/kms.tf
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "cloudtrail_kms" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = [aws_cloudtrail.main.arn]
+      values   = ["arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/prsd-cloudtrail-${var.environment_name}"]
     }
   }
 }


### PR DESCRIPTION
## Ticket number

PRSD-1178

## Goal of change

Removes circular dependency in Cloudtrail kms policy that was preventing the creation of our cloudtrail

## Description of main change(s)

Summary of the changes made. These should focus on the functionality that you've changed rather than the actual code
changes - those will be clear from the PR.
E.g. Prefer "Adds new endpoint for uploading gas safety certificates to s3" to "Adds new `UploadGasSafetyCertificate`
controller that accepts a `UploadFileRequest` and uses the `fileUploadService` to upload the file to s3"

## Anything you'd like to highlight to the reviewer?

As part of debugging this has already been applied to integration