### PR TITLE
PRSD-1166: Turn on require-passcode profile in prod and test

### DIFF
--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -107,10 +107,10 @@ locals {
       name  = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
       value = data.aws_ssm_parameter.google_analytics_cookie_domain.value
     },
-    # {
-    #   name  = "SPRING_PROFILES_ACTIVE"
-    #   value = "default,require-passcode"
-    # }
+    {
+      name  = "SPRING_PROFILES_ACTIVE"
+      value = "default,require-passcode"
+    },
     {
       name  = "EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY"
       value = contains(["production"], local.environment_name) ? "true" : "false"

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -109,7 +109,7 @@ locals {
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"
-      value = "default"
+      value = "default,require-passcode"
     },
     {
       name  = "EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY"


### PR DESCRIPTION
## Ticket number

PRSD-1166

## Goal of change

Turn on require-passcode profile in prod and test environments

## Description of main change(s)

As above

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist
Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done