### PR TITLE
PRSD-1441: Add new environment variable

### DIFF
--- a/terraform/environment_template/ecs_task_definition/data.tf.template
+++ b/terraform/environment_template/ecs_task_definition/data.tf.template
@@ -107,3 +107,7 @@ data "aws_ssm_parameter" "google_analytics_measurement_id" {
 data "aws_ssm_parameter" "google_analytics_cookie_domain" {
   name = "${local.environment_name}-prsdb-google-analytics-cookie-domain"
 }
+
+data "aws_ssm_parameter" "beta_feedback_team_email_address" {
+  name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
+}

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -115,6 +115,10 @@ locals {
       name  = "EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY"
       value = contains(["production"], local.environment_name) ? "true" : "false"
     },
+    {
+      name = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"
+      value = data.aws_ssm_parameter.beta_feedback_team_email_address.value
+    },
   ]
   secrets = [
     {

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -107,3 +107,7 @@ data "aws_ssm_parameter" "google_analytics_measurement_id" {
 data "aws_ssm_parameter" "google_analytics_cookie_domain" {
   name = "${local.environment_name}-prsdb-google-analytics-cookie-domain"
 }
+
+data "aws_ssm_parameter" "beta_feedback_team_email_address" {
+  name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
+}

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -115,6 +115,10 @@ locals {
       name  = "EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY"
       value = contains(["production"], local.environment_name) ? "true" : "false"
     },
+    {
+      name  = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"
+      value = data.aws_ssm_parameter.beta_feedback_team_email_address.value
+    },
   ]
   secrets = [
     {

--- a/terraform/modules/ssm/parameters.tf
+++ b/terraform/modules/ssm/parameters.tf
@@ -121,3 +121,13 @@ resource "aws_ssm_parameter" "google_analytics_cookie_domain" {
     ignore_changes = [value]
   }
 }
+
+resource "aws_ssm_parameter" "beta_feedback_team_email_address" {
+  name  = "${var.environment_name}-prsdb-beta-feedback-team-email-address"
+  type  = "String"
+  value = "default_to_be_set_manually" # To be set manually on AWS
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -107,3 +107,7 @@ data "aws_ssm_parameter" "google_analytics_measurement_id" {
 data "aws_ssm_parameter" "google_analytics_cookie_domain" {
   name = "${local.environment_name}-prsdb-google-analytics-cookie-domain"
 }
+
+data "aws_ssm_parameter" "beta_feedback_team_email_address" {
+  name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
+}

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -115,6 +115,10 @@ locals {
       name  = "EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY"
       value = contains(["production"], local.environment_name) ? "true" : "false"
     },
+    {
+      name  = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"
+      value = data.aws_ssm_parameter.beta_feedback_team_email_address.value
+    },
   ]
   secrets = [
     {


### PR DESCRIPTION
## Ticket number

PRSD-1441

## Goal of change

Adds a new environment variable for the email address that feedback should be sent to

## Description of main change(s)

Adds a new environment variable for the email address that feedback should be sent to

## Anything you'd like to highlight to the reviewer?

## Checklist
Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [ ] Any special release instructions (e.g. set environment variables) have been added as checklist items to a draft PR (merging `main` into `test`) for the next release.

  Make sure to include details such as the name of the variable, where it needs to be set (e.g. AWS Secrets Manager or Parameter Store), and what it should be set to (this might be a location in keeper where a secret value can be found)