### PR TITLE
PRSD-1178: Replace ConsoleLogin alarm with AssumeRoleWithSaml alarm

### DIFF
--- a/terraform/modules/monitoring/alarms.tf
+++ b/terraform/modules/monitoring/alarms.tf
@@ -1,9 +1,9 @@
-resource "aws_cloudwatch_metric_alarm" "console_login" {
-  alarm_name          = "console-login-${var.environment_name}"
-  alarm_description   = "Someone has logged in to the AWS console"
+resource "aws_cloudwatch_metric_alarm" "assume_role_with_saml" {
+  alarm_name          = "assume-role-with-saml-${var.environment_name}"
+  alarm_description   = "Someone has assumed an AWS role from AWS Console or from the command line using AWS Vault"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   treat_missing_data  = "notBreaching"
-  metric_name         = aws_cloudwatch_log_metric_filter.console_login.name
+  metric_name         = aws_cloudwatch_log_metric_filter.assume_role_with_saml.name
   evaluation_periods  = 1
   period              = 60
   threshold           = 1
@@ -14,5 +14,3 @@ resource "aws_cloudwatch_metric_alarm" "console_login" {
     aws_sns_topic.alarm_sns_topic.arn,
   ]
 }
-
-

--- a/terraform/modules/monitoring/metrics.tf
+++ b/terraform/modules/monitoring/metrics.tf
@@ -1,12 +1,12 @@
-resource "aws_cloudwatch_log_metric_filter" "console_login" {
+resource "aws_cloudwatch_log_metric_filter" "assume_role_with_saml" {
   log_group_name = module.cloudtrail_cloudwatch_group.name
-  name           = "console_login_${var.environment_name}"
+  name           = "assume_role_with_saml_${var.environment_name}"
   pattern        = <<EOT
-    {($.eventName = "ConsoleLogin") && ($.responseElements.ConsoleLogin = "Success")}
+    {($.eventName = "AssumeRoleWithSAML")}
   EOT
 
   metric_transformation {
-    name      = "console_login_${var.environment_name}"
+    name      = "assume_role_with_saml_${var.environment_name}"
     namespace = "prsd/${var.environment_name}/security"
     value     = "1"
   }


### PR DESCRIPTION
## Ticket number

PRSD-1178

## Goal of change

Fire an alarm when someone either logs in via AWS Console or AWS Vault

## Description of main change(s)

Replace ConsoleLogin alarm with AssumeRoleWithSaml alarm. The ConsoleLogin event was only firing when a user logs in on AWS Console, but AssumeRoleWithSaml fires when someone assumes a role from the console or the vault.

## Anything you'd like to highlight to the reviewer?

This is untested, do I need to change anything else? Are there any release actions to make the alarm send an email?

## Checklist
Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [ ] Any special release instructions (e.g. set environment variables) have been added as checklist items to a draft PR (merging `main` into `test`) for the next release.

  Make sure to include details such as the name of the variable, where it needs to be set (e.g. AWS Secrets Manager or Parameter Store), and what it should be set to (this might be a location in keeper where a secret value can be found)