### PR TITLE
PRSD-NONE: Remove duplicate expiration block on S3 bucket

### DIFF
--- a/terraform/modules/monitoring/s3.tf
+++ b/terraform/modules/monitoring/s3.tf
@@ -6,7 +6,7 @@ module "s3_bucket" {
   access_s3_log_expiration_days      = var.cloudwatch_log_expiration_days
   policy                             = data.aws_iam_policy_document.bucket_policy.json
   kms_key_arn                        = aws_kms_key.main.arn
-  noncurrent_version_expiration_days = var.cloudwatch_log_expiration_days
+  noncurrent_version_expiration_days = null
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "expire" {
@@ -20,6 +20,11 @@ resource "aws_s3_bucket_lifecycle_configuration" "expire" {
     expiration {
       days = var.cloudwatch_log_expiration_days
     }
+
+    noncurrent_version_expiration {
+      noncurrent_days = var.cloudwatch_log_expiration_days
+    }
+
     status = "Enabled"
   }
 }


### PR DESCRIPTION
## Ticket number

PRSD-NONE

## Goal of change

Remove the extra expiration block on the Cloudtrail S3 bucket which causes new deployments to fail the first time

## Description of main change(s)

Turns off the expiration block created by the S3 module and adds expiration of versions to the custom expiration block in the monitoring module