### PR TITLE
PRSD-1491: Exclude maintenance endpoint from url_rewriter

### DIFF
--- a/terraform/modules/frontdoor/url_rewriter.js
+++ b/terraform/modules/frontdoor/url_rewriter.js
@@ -1,5 +1,5 @@
 function handler(event) {
-    const exceptions = ["signout","confirm-sign-out", "error", "assets", "id-verification", "logout", "oauth2", "healthcheck", "cookies"];
+    const exceptions = ["signout","confirm-sign-out", "error", "assets", "id-verification", "logout", "oauth2", "healthcheck", "cookies", "maintenance"];
     const request = event.request;
     const hostName = request.headers.host.value;
     let pathSegments = request.uri.split('/');

--- a/test/js/url_rewriter.test.js
+++ b/test/js/url_rewriter.test.js
@@ -303,6 +303,17 @@ describe('url_rewriter', () => {
             // then
             expect(new_event.headers.host.value + new_event.uri).toBe('https://search-landlord-home-information.communities.gov.uk/cookies');
         });
+
+        it('returns the original url for the /maintenance endpoint', () => {
+            // given
+            const event = createRequestEvent(searchLandlordHomeInformationHost, '/maintenance');
+
+            // when
+            const new_event = url_rewriter(event);
+
+            // then
+            expect(new_event.headers.host.value + new_event.uri).toBe('https://search-landlord-home-information.communities.gov.uk/maintenance');
+        });
     });
 });
 

--- a/test/js/url_rewriter.test.js
+++ b/test/js/url_rewriter.test.js
@@ -157,6 +157,17 @@ describe('url_rewriter', () => {
             // then
             expect(new_event.headers.host.value + new_event.uri).toBe('https://register-home-to-rent.communities.gov.uk/cookies');
         });
+
+        it('returns the original url for the /maintenance endpoint', () => {
+            // given
+            const event = createRequestEvent(registerHomeToRentHost, '/maintenance');
+
+            // when
+            const new_event = url_rewriter(event);
+
+            // then
+            expect(new_event.headers.host.value + new_event.uri).toBe('https://register-home-to-rent.communities.gov.uk/maintenance');
+        });
     });
 
     describe('for the search-landlord-home-information domain', () => {


### PR DESCRIPTION
## Ticket number

PRSD-1491

## Goal of change

Create a maintenance page that users are re-directed to if the service has been taken down

## Description of main change(s)

Exclude the "maintenance" endpoint from url_rewriter

## Anything you'd like to highlight to the reviewer?

## Checklist
Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done
