### PR TITLE
Feat/prsd 981 - ssm patch manager for bastions

### DIFF
--- a/terraform/environment_template/main.tf.template
+++ b/terraform/environment_template/main.tf.template
@@ -142,6 +142,8 @@ module "bastion" {
   environment_name   = local.environment_name
   main_vpc_id        = module.networking.vpc.id
   vpc_cidr_block     = module.networking.vpc.cidr_block
+
+  bastion_ssm_patch_cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
 }
 
 module "database" {

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -153,6 +153,8 @@ module "bastion" {
   environment_name   = local.environment_name
   main_vpc_id        = module.networking.vpc.id
   vpc_cidr_block     = module.networking.vpc.cidr_block
+
+  bastion_ssm_patch_cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
 }
 
 module "database" {

--- a/terraform/modules/bastion/iam.tf
+++ b/terraform/modules/bastion/iam.tf
@@ -30,11 +30,6 @@ resource "aws_iam_role_policy_attachment" "ssm_bastion_maintenance_window" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMMaintenanceWindowRole"
 }
 
-resource "aws_iam_role_policy_attachment" "ssm_bastion_managed_instance_core" {
-  role       = aws_iam_role.ssm_bastion.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}
-
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 

--- a/terraform/modules/bastion/iam.tf
+++ b/terraform/modules/bastion/iam.tf
@@ -30,16 +30,7 @@ resource "aws_iam_role_policy_attachment" "ssm_bastion_maintenance_window" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMMaintenanceWindowRole"
 }
 
-data "aws_iam_policy_document" "ssm_send_command_policy_doc" {
-  statement {
-    actions   = ["ssm:SendCommand"]
-    effect    = "Allow"
-    resources = ["arn:aws:ssm:us-east-1::document/AWS-RunRemoteScript"]
-  }
-}
-
-resource "aws_iam_role_policy" "ssm_bastion_send_command_role_policy" {
-  name   = "${var.environment_name}-bastion-send-command-role-policy"
-  role   = aws_iam_role.ssm_bastion.name
-  policy = data.aws_iam_policy_document.ssm_send_command_policy_doc.json
+resource "aws_iam_role_policy_attachment" "ssm_bastion_managed_instance_core" {
+  role       = aws_iam_role.ssm_bastion.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }

--- a/terraform/modules/bastion/iam.tf
+++ b/terraform/modules/bastion/iam.tf
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "bastion_logs_assume_role" {
     condition {
       test     = "ArnLike"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vpc-flow-log/*"]
+      values   = ["arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:bastion-log/*"]
     }
   }
 }

--- a/terraform/modules/bastion/iam.tf
+++ b/terraform/modules/bastion/iam.tf
@@ -24,3 +24,27 @@ resource "aws_iam_instance_profile" "ssm_bastion" {
   name = "${var.environment_name}-bastion-instance-profile"
   role = aws_iam_role.ssm_bastion.name
 }
+
+resource "aws_iam_role_policy_attachment" "ssm_bastion_maintenance_window" {
+  role       = aws_iam_role.ssm_bastion.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMMaintenanceWindowRole"
+}
+
+data "aws_iam_policy_document" "ssm_send_command_policy_doc" {
+  statement {
+    actions   = ["ssm:SendCommand"]
+    effect    = "Allow"
+    resources = ["arn:aws:ssm:us-east-1::document/AWS-RunRemoteScript"]
+  }
+}
+
+resource "aws_iam_role_policy" "ssm_bastion_send_command_role_policy" {
+  name   = "${var.environment_name}-bastion-send-command-role-policy"
+  role   = aws_iam_role.ssm_bastion.name
+  policy = data.aws_iam_policy_document.ssm_send_command_policy_doc.json
+}
+
+# Allows running SSM remote commands on EC2 instances
+data "aws_iam_role" "aws_service_role_for_ssm" {
+  name = "${var.environment_name}-aws-service-role-for-ssm"
+}

--- a/terraform/modules/bastion/iam.tf
+++ b/terraform/modules/bastion/iam.tf
@@ -43,8 +43,3 @@ resource "aws_iam_role_policy" "ssm_bastion_send_command_role_policy" {
   role   = aws_iam_role.ssm_bastion.name
   policy = data.aws_iam_policy_document.ssm_send_command_policy_doc.json
 }
-
-# Allows running SSM remote commands on EC2 instances
-data "aws_iam_role" "aws_service_role_for_amazon_ssm" {
-  name = "AWSServiceRoleForAmazonSSM"
-}

--- a/terraform/modules/bastion/iam.tf
+++ b/terraform/modules/bastion/iam.tf
@@ -34,3 +34,55 @@ resource "aws_iam_role_policy_attachment" "ssm_bastion_managed_instance_core" {
   role       = aws_iam_role.ssm_bastion.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+data "aws_iam_policy_document" "bastion_logs_assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vpc-flow-log/*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "bastion_logs" {
+  name               = "bastion-logs-role-${var.environment_name}"
+  assume_role_policy = data.aws_iam_policy_document.bastion_logs_assume_role.json
+}
+
+# tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "bastion_logs" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "bastion_logs" {
+  name = "bastion-logs-cloudwatch-policy-${var.environment_name}"
+  role = aws_iam_role.bastion_logs.id
+
+  policy = data.aws_iam_policy_document.bastion_logs.json
+}

--- a/terraform/modules/bastion/iam.tf
+++ b/terraform/modules/bastion/iam.tf
@@ -45,6 +45,6 @@ resource "aws_iam_role_policy" "ssm_bastion_send_command_role_policy" {
 }
 
 # Allows running SSM remote commands on EC2 instances
-data "aws_iam_role" "aws_service_role_for_ssm" {
-  name = "${var.environment_name}-aws-service-role-for-ssm"
+data "aws_iam_role" "aws_service_role_for_amazon_ssm" {
+  name = "AWSServiceRoleForAmazonSSM"
 }

--- a/terraform/modules/bastion/logging.tf
+++ b/terraform/modules/bastion/logging.tf
@@ -1,9 +1,12 @@
-#tfsec:ignore:aws-cloudwatch-log-group-customer-key
-resource "aws_cloudwatch_log_group" "bastion_log_group" {
-  name              = "${var.environment_name}-bastion"
-  retention_in_days = 60
+resource "aws_flow_log" "bastion_ssm_patch" {
+  iam_role_arn    = aws_iam_role.bastion_logs.arn
+  log_destination = module.bastion_logs.log_group_arn
+  traffic_type    = "ALL"
+}
 
-  tags = {
-    Application = var.environment_name
-  }
+module "bastion_logs" {
+  source = "../../modules/encrypted_log_group"
+
+  log_group_name     = "${var.environment_name}-bastion-ssm-patch-logs"
+  log_retention_days = var.bastion_ssm_patch_cloudwatch_log_expiration_days
 }

--- a/terraform/modules/bastion/logging.tf
+++ b/terraform/modules/bastion/logging.tf
@@ -1,7 +1,12 @@
 resource "aws_flow_log" "bastion_ssm_patch" {
+  count           = length(var.bastion_subnet_ids)
   iam_role_arn    = aws_iam_role.bastion_logs.arn
   log_destination = module.bastion_logs.log_group_arn
   traffic_type    = "ALL"
+  vpc_id          = var.bastion_subnet_ids[count.index]
+  tags = {
+    Name = "${var.environment_name}-bastion-${count.index + 1}"
+  }
 }
 
 module "bastion_logs" {

--- a/terraform/modules/bastion/logging.tf
+++ b/terraform/modules/bastion/logging.tf
@@ -3,7 +3,7 @@ resource "aws_flow_log" "bastion_ssm_patch" {
   iam_role_arn    = aws_iam_role.bastion_logs.arn
   log_destination = module.bastion_logs.log_group_arn
   traffic_type    = "ALL"
-  vpc_id          = var.bastion_subnet_ids[count.index]
+  subnet_id       = var.bastion_subnet_ids[count.index]
   tags = {
     Name = "${var.environment_name}-bastion-${count.index + 1}"
   }

--- a/terraform/modules/bastion/logging.tf
+++ b/terraform/modules/bastion/logging.tf
@@ -1,3 +1,4 @@
+#tfsec:ignore:aws-cloudwatch-log-group-customer-key
 resource "aws_cloudwatch_log_group" "bastion_log_group" {
   name              = "${var.environment_name}-bastion"
   retention_in_days = 60

--- a/terraform/modules/bastion/logging.tf
+++ b/terraform/modules/bastion/logging.tf
@@ -1,0 +1,8 @@
+resource "aws_cloudwatch_log_group" "bastion_log_group" {
+  name              = "${var.environment_name}-bastion"
+  retention_in_days = 60
+
+  tags = {
+    Application = var.environment_name
+  }
+}

--- a/terraform/modules/bastion/ssm_patch.tf
+++ b/terraform/modules/bastion/ssm_patch.tf
@@ -1,16 +1,3 @@
-resource "aws_ssm_patch_baseline" "bastion_patch" {
-  name             = "${var.environment_name}-patch-baseline"
-  operating_system = "AMAZON_LINUX_2"
-  approval_rule {
-    enable_non_security = true # Set to true to install non-security updates
-    approve_after_days  = 7
-    patch_filter {
-      key    = "CLASSIFICATION"
-      values = ["*"]
-    }
-  }
-}
-
 resource "aws_ssm_maintenance_window" "bastion_patch" {
   name        = "${var.environment_name}-ssm-patch-window"
   schedule    = "cron(0 2 ? * WED *)" # Every Wednesday at 2 AM UTC
@@ -31,9 +18,7 @@ resource "aws_ssm_maintenance_window_task" "bastion_patch" {
 
   task_invocation_parameters {
     run_command_parameters {
-      comment          = "Amazon Linux 2 Patch Baseline Install"
-      document_version = "$LATEST"
-      timeout_seconds  = 3600
+      comment          = "Default Baseline Install"
       cloudwatch_config {
         cloudwatch_log_group_name = aws_cloudwatch_log_group.bastion_log_group.id
         cloudwatch_output_enabled = true

--- a/terraform/modules/bastion/ssm_patch.tf
+++ b/terraform/modules/bastion/ssm_patch.tf
@@ -1,15 +1,15 @@
 resource "aws_ssm_maintenance_window" "bastion_patch" {
-  name        = "${var.environment_name}-ssm-patch-window"
-  schedule    = "cron(0 2 ? * WED *)" # Every Wednesday at 2 AM UTC
-  duration    = 3
-  cutoff      = 1
+  name     = "${var.environment_name}-ssm-patch-window"
+  schedule = "cron(0 2 ? * WED *)" # Every Wednesday at 2 AM UTC
+  duration = 3
+  cutoff   = 1
 }
 
 resource "aws_ssm_maintenance_window_task" "bastion_patch" {
-  window_id        = aws_ssm_maintenance_window.bastion_patch.id
-  task_type        = "RUN_COMMAND"
-  task_arn         = "AWS-RunPatchBaseline"
-  priority         = 1
+  window_id = aws_ssm_maintenance_window.bastion_patch.id
+  task_type = "RUN_COMMAND"
+  task_arn  = "AWS-RunPatchBaseline"
+  priority  = 1
 
   targets {
     key    = "InstanceIds"
@@ -18,7 +18,7 @@ resource "aws_ssm_maintenance_window_task" "bastion_patch" {
 
   task_invocation_parameters {
     run_command_parameters {
-      comment          = "Default Baseline Install"
+      comment = "Default Baseline Install"
       cloudwatch_config {
         cloudwatch_log_group_name = aws_cloudwatch_log_group.bastion_log_group.id
         cloudwatch_output_enabled = true

--- a/terraform/modules/bastion/ssm_patch.tf
+++ b/terraform/modules/bastion/ssm_patch.tf
@@ -19,10 +19,6 @@ resource "aws_ssm_maintenance_window_task" "bastion_patch" {
   task_invocation_parameters {
     run_command_parameters {
       comment = "Default Baseline Install"
-      cloudwatch_config {
-        cloudwatch_log_group_name = aws_cloudwatch_log_group.bastion_log_group.id
-        cloudwatch_output_enabled = true
-      }
       parameter {
         name   = "Operation"
         values = ["Install"]

--- a/terraform/modules/bastion/ssm_patch.tf
+++ b/terraform/modules/bastion/ssm_patch.tf
@@ -1,0 +1,59 @@
+resource "aws_ssm_patch_baseline" "bastion_patch" {
+  name             = "${var.environment_name}-patch-baseline"
+  operating_system = "AMAZON_LINUX_2"
+  approval_rule {
+    enable_non_security = true # Set to true to install non-security updates
+    approve_after_days  = 7
+    patch_filter {
+      key    = "CLASSIFICATION"
+      values = ["*"]
+    }
+  }
+}
+
+resource "aws_ssm_maintenance_window" "bastion_patch" {
+  name        = "${var.environment_name}-ssm-patch-window"
+  schedule    = "cron(0 2 ? * WED *)" # Every Wednesday at 2 AM UTC
+  duration    = 3
+  cutoff      = 1
+}
+
+resource "aws_ssm_maintenance_window_task" "bastion_patch" {
+  window_id        = aws_ssm_maintenance_window.bastion_patch.id
+  task_type        = "RUN_COMMAND"
+  task_arn         = "AWS-RunPatchBaseline"
+  priority         = 1
+  service_role_arn = data.aws_iam_role.aws_service_role_for_amazon_ssm.arn
+
+  targets {
+    key    = "InstanceIds"
+    values = aws_instance.bastion[*].id
+  }
+
+  task_invocation_parameters {
+    run_command_parameters {
+      comment          = "Amazon Linux 2 Patch Baseline Install"
+      document_version = "$LATEST"
+      timeout_seconds  = 3600
+      cloudwatch_config {
+        cloudwatch_log_group_name = aws_cloudwatch_log_group.bastion_log_group.id
+        cloudwatch_output_enabled = true
+      }
+      parameter {
+        name   = "Operation"
+        values = ["Install"]
+      }
+    }
+  }
+}
+
+# Auto Update SSM agents on existing instances
+resource "aws_ssm_association" "bastion_patch_ssm_agent_update" {
+  name                = "AWS-UpdateSSMAgent"
+  schedule_expression = "cron(0 2 ? * TUE *)" # Every Tuesday at 2 AM UTC
+
+  targets {
+    key    = "InstanceIds"
+    values = aws_instance.bastion[*].id
+  }
+}

--- a/terraform/modules/bastion/ssm_patch.tf
+++ b/terraform/modules/bastion/ssm_patch.tf
@@ -23,7 +23,6 @@ resource "aws_ssm_maintenance_window_task" "bastion_patch" {
   task_type        = "RUN_COMMAND"
   task_arn         = "AWS-RunPatchBaseline"
   priority         = 1
-  service_role_arn = data.aws_iam_role.aws_service_role_for_amazon_ssm.arn
 
   targets {
     key    = "InstanceIds"

--- a/terraform/modules/bastion/variables.tf
+++ b/terraform/modules/bastion/variables.tf
@@ -21,3 +21,8 @@ variable "bastion_subnet_ids" {
   type        = list(string)
   description = "The private subnets into which to deploy a bastion"
 }
+
+variable "bastion_ssm_patch_cloudwatch_log_expiration_days" {
+  type        = number
+  description = "Number of days to retain SSM bastion patch logs for"
+}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -151,6 +151,8 @@ module "bastion" {
   environment_name   = local.environment_name
   main_vpc_id        = module.networking.vpc.id
   vpc_cidr_block     = module.networking.vpc.cidr_block
+
+  bastion_ssm_patch_cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
 }
 
 module "database" {

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -153,6 +153,8 @@ module "bastion" {
   environment_name   = local.environment_name
   main_vpc_id        = module.networking.vpc.id
   vpc_cidr_block     = module.networking.vpc.cidr_block
+
+  bastion_ssm_patch_cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
 }
 
 module "database" {


### PR DESCRIPTION
## Ticket number

PRSD-981

## Goal of change

Add SSM patch manager to patch the bastion host

## Description of main change(s)

- Add some built in ssm policies to the existing aws_iam_role.ssm_bastion
- Sets up a maintenance window when patching will be done (set to 2am on wednesday mornings - I'm hoping this would be a quiet time!)
- Add a task to run "AWS-RunPatchBaseline" in the maintenance window
    - this should run the default baseline patches for the operating system of the bastion, in our case this is AWS-AmazonLinux2DefaultPatchBaseline
    - From [docs](https://docs.aws.amazon.com/systems-manager/latest/userguide/patch-manager-predefined-and-custom-patch-baselines.html), this `Approves all operating system patches that are classified as "Security" and that have a severity level of "Critical" or "Important". Also approves all patches with a classification of "Bugfix". Patches are auto-approved 7 days after release.`
- Sets an association which will hopefully update the SSM agent doing the patching (every Tuesday at 2am, so it's up to date for when it does the patching)
- Enable cloudwatch logging

## Anything you'd like to highlight to the reviewer?

Used [this blog](https://shadabambat1.medium.com/patch-your-ec2-instances-automatically-using-systems-manager-and-terraform-696ba391b049) as a starting point, but simplified by using more in-built (default) options

## Checklist
Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done
