### PR TITLE
PRSD-1526: Resource Metric CloudWatch Alarms

### DIFF
--- a/terraform/environment_template/main.tf.template
+++ b/terraform/environment_template/main.tf.template
@@ -39,6 +39,7 @@ locals {
   load_balancer_domain_name = "${local.environment_name}.lb.register-home-to-rent.test.communities.gov.uk"
 
   cloudwatch_log_expiration_days = <log retention period>
+  database_allocated_storage     = <storage amount>
 }
 
 module "networking" {
@@ -152,7 +153,7 @@ module "database" {
   environment_name                = local.environment_name
   database_password               = module.secrets.database_password.result
   database_port                   = local.database_port
-  allocated_storage               = <storage amount>
+  allocated_storage               = local.database_allocated_storage
   backup_retention_period         = <backup retention period>
   db_subnet_group_name            = module.networking.db_subnet_group_name
   instance_class                  = "<instance class>"
@@ -201,4 +202,21 @@ module "file_upload" {
   ecs_cluster_arn                 = module.ecs_service[0].ecs_cluster_arn
   private_subnet_ids              = module.networking.private_subnets[*].id
   ecs_security_group_ids          = module.ecs_service[0].ecs_security_group_ids
+}
+
+module "monitoring" {
+  source = "../modules/monitoring"
+
+  environment_name               = local.environment_name
+  cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
+  alarm_email_address            = var.alarm_email_address
+  alb_arn_suffix                 = module.frontdoor.load_balancer.arn_suffix
+  alb_target_group_arn           = module.frontdoor.load_balancer.target_group_arn
+  ecs_cluster_name               = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
+  ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
+  elasticache_cluster_id         = module.redis.redis_cluster_id
+  elasticache_node_ids           = toset(module.redis.redis_node_ids)
+  rds_instance_allocated_storage = local.database_allocated_storage
+  rds_instance_id                = module.database.rds_instance_id
+  waf_acl_name                   = module.frontdoor.waf_acl_name
 }

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -39,6 +39,7 @@ locals {
   load_balancer_domain_name = "${local.environment_name}.lb.register-home-to-rent.test.communities.gov.uk"
 
   cloudwatch_log_expiration_days = 60
+  database_allocated_storage     = 50
 }
 
 module "networking" {
@@ -162,7 +163,7 @@ module "database" {
   environment_name                = local.environment_name
   database_password               = module.secrets.database_password.result
   database_port                   = local.database_port
-  allocated_storage               = 50
+  allocated_storage               = local.database_allocated_storage
   backup_retention_period         = 7
   db_subnet_group_name            = module.networking.db_subnet_group_name
   instance_class                  = "db.t4g.small"
@@ -219,4 +220,13 @@ module "monitoring" {
   environment_name               = local.environment_name
   cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
   alarm_email_address            = var.alarm_email_address
+  alb_arn_suffix                 = module.frontdoor.load_balancer.arn_suffix
+  alb_target_group_arn           = module.frontdoor.load_balancer.target_group_arn
+  ecs_cluster_name               = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
+  ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
+  elasticache_cluster_id         = module.redis.redis_cluster_id
+  elasticache_node_ids           = toset(module.redis.redis_node_ids)
+  rds_instance_allocated_storage = local.database_allocated_storage
+  rds_instance_id                = module.database.rds_instance_id
+  waf_acl_name                   = module.frontdoor.waf_acl_name
 }

--- a/terraform/modules/ecs_service/outputs.tf
+++ b/terraform/modules/ecs_service/outputs.tf
@@ -3,9 +3,19 @@ output "ecs_cluster_arn" {
   description = "The arn of the ecs cluster for this environment"
 }
 
+output "ecs_cluster_name" {
+  value       = aws_ecs_cluster.main.name
+  description = "The name of the ECS cluster for this environment"
+}
+
 output "ecs_service_arn" {
   value       = aws_ecs_service.webapp.id
   description = "The ARN of the ECS service for the web application"
+}
+
+output "ecs_service_name" {
+  value       = aws_ecs_service.webapp.name
+  description = "The name of the ECS service for the web application"
 }
 
 output "ecs_security_group_ids" {

--- a/terraform/modules/elasticache/outputs.tf
+++ b/terraform/modules/elasticache/outputs.tf
@@ -2,3 +2,13 @@ output "redis_security_group_id" {
   value       = aws_security_group.redis.id
   description = "ID for the security group for redis"
 }
+
+output "redis_cluster_id" {
+  value       = aws_elasticache_replication_group.main.id
+  description = "ID of the redis cluster"
+}
+
+output "redis_node_ids" {
+  value       = aws_elasticache_replication_group.main.member_clusters
+  description = "IDs of the redis nodes"
+}

--- a/terraform/modules/frontdoor/outputs.tf
+++ b/terraform/modules/frontdoor/outputs.tf
@@ -14,3 +14,8 @@ output "cloudfront_dns_name" {
   description = "The domain name of the cloudfront distribution"
   value       = aws_cloudfront_distribution.main.domain_name
 }
+
+output "waf_acl_name" {
+  description = "The name of the WAF Web ACL"
+  value       = aws_wafv2_web_acl.main.name
+}

--- a/terraform/modules/monitoring/cloudwatch.tf
+++ b/terraform/modules/monitoring/cloudwatch.tf
@@ -1,0 +1,18 @@
+resource "aws_cloudwatch_event_rule" "ecs_events" {
+  name          = "${var.environment_name}-ecs-events"
+  description   = "Capture ECS events"
+  event_pattern = jsonencode({
+    "source": ["aws.ecs"],
+  })
+}
+
+resource "aws_cloudwatch_log_group" "ecs_events" {
+  name              = "${var.environment_name}-ecs-events"
+  retention_in_days = 1
+}
+
+resource "aws_cloudwatch_event_target" "ecs_events_to_logs" {
+  target_id = "${var.environment_name}-ecs-events-to-logs"
+  rule      = aws_cloudwatch_event_rule.ecs_events.name
+  arn       = aws_cloudwatch_log_group.ecs_events.arn
+}

--- a/terraform/modules/monitoring/cloudwatch.tf
+++ b/terraform/modules/monitoring/cloudwatch.tf
@@ -1,18 +1,21 @@
 resource "aws_cloudwatch_event_rule" "ecs_events" {
   name        = "${var.environment_name}-ecs-events"
   description = "Capture ECS events"
+
   event_pattern = jsonencode({
     "source" : ["aws.ecs"],
   })
 }
 
-resource "aws_cloudwatch_log_group" "ecs_events" {
-  name              = "${var.environment_name}-ecs-events"
-  retention_in_days = 1
+module "ecs_events_log_group" {
+  source = "../encrypted_log_group"
+
+  log_group_name     = "${var.environment_name}-ecs-events"
+  log_retention_days = 1
 }
 
 resource "aws_cloudwatch_event_target" "ecs_events_to_logs" {
   target_id = "${var.environment_name}-ecs-events-to-logs"
   rule      = aws_cloudwatch_event_rule.ecs_events.name
-  arn       = aws_cloudwatch_log_group.ecs_events.arn
+  arn       = module.ecs_events_log_group.log_group_arn
 }

--- a/terraform/modules/monitoring/cloudwatch.tf
+++ b/terraform/modules/monitoring/cloudwatch.tf
@@ -1,8 +1,8 @@
 resource "aws_cloudwatch_event_rule" "ecs_events" {
-  name          = "${var.environment_name}-ecs-events"
-  description   = "Capture ECS events"
+  name        = "${var.environment_name}-ecs-events"
+  description = "Capture ECS events"
   event_pattern = jsonencode({
-    "source": ["aws.ecs"],
+    "source" : ["aws.ecs"],
   })
 }
 

--- a/terraform/modules/monitoring/metrics.tf
+++ b/terraform/modules/monitoring/metrics.tf
@@ -191,3 +191,18 @@ resource "aws_cloudwatch_log_metric_filter" "organization_changes" {
     value     = "1"
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "ecs_task_start_failure" {
+  log_group_name = aws_cloudwatch_log_group.ecs_events.name
+  name           = "ecs-task-start-failure-${var.environment_name}"
+  pattern        = <<EOT
+    {($.detail.stopCode = "TaskFailedToStart") &&
+     ($.detail-type = "ECS Task State Change")}
+  EOT
+
+  metric_transformation {
+    name      = "ecs-task-start-failure-${var.environment_name}"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}

--- a/terraform/modules/monitoring/metrics.tf
+++ b/terraform/modules/monitoring/metrics.tf
@@ -193,7 +193,7 @@ resource "aws_cloudwatch_log_metric_filter" "organization_changes" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "ecs_task_start_failure" {
-  log_group_name = aws_cloudwatch_log_group.ecs_events.name
+  log_group_name = module.ecs_events_log_group.name
   name           = "ecs-task-start-failure-${var.environment_name}"
   pattern        = <<EOT
     {($.detail.stopCode = "TaskFailedToStart") &&

--- a/terraform/modules/monitoring/resource_alarms.tf
+++ b/terraform/modules/monitoring/resource_alarms.tf
@@ -52,6 +52,22 @@ resource "aws_cloudwatch_metric_alarm" "ecs_memory_usage" {
   ]
 }
 
+resource "aws_cloudwatch_metric_alarm" "ecs_task_start_failure" {
+  alarm_name          = "${var.ecs_service_name}-ecs-task-start-failure"
+  alarm_description   = "An ECS task has failed to start and reach a healthy state"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  metric_name         = "ecs_task_start_failure"
+  namespace           = "LogMetrics"
+  evaluation_periods  = 1
+  period              = 60
+  threshold           = 1
+  statistic           = "Sum"
+
+  alarm_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+}
+
 resource "aws_cloudwatch_metric_alarm" "rds_cpu_usage" {
   alarm_name          = "${var.rds_instance_id}-cpu-usage"
   alarm_description   = "RDS Database CPU utilization has been >90% for over a minute"

--- a/terraform/modules/monitoring/resource_alarms.tf
+++ b/terraform/modules/monitoring/resource_alarms.tf
@@ -1,0 +1,266 @@
+resource "aws_cloudwatch_metric_alarm" "ecs_cpu_usage" {
+  alarm_name          = "${var.ecs_service_name}-cpu-usage"
+  alarm_description   = "ECS CPU utilization has been >90% for over a minute"
+  comparison_operator = "GreaterThanThreshold"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  evaluation_periods  = 1
+  period              = 60
+  threshold           = 90
+  statistic           = "Average"
+
+  dimensions = {
+    ClusterName = var.ecs_cluster_name
+    ServiceName = var.ecs_service_name
+  }
+
+  alarm_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  ok_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  insufficient_data_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_memory_usage" {
+  alarm_name          = "${var.ecs_service_name}-memory-usage"
+  alarm_description   = "ECS memory usage has been >90% for over a minute"
+  comparison_operator = "GreaterThanThreshold"
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  evaluation_periods  = 1
+  period              = 60
+  threshold           = 90
+  statistic           = "Average"
+
+  dimensions = {
+    ClusterName = var.ecs_cluster_name
+    ServiceName = var.ecs_service_name
+  }
+
+  alarm_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  ok_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  insufficient_data_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_cpu_usage" {
+  alarm_name          = "${var.rds_instance_id}-cpu-usage"
+  alarm_description   = "RDS Database CPU utilization has been >90% for over a minute"
+  comparison_operator = "GreaterThanThreshold"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  evaluation_periods  = 1
+  period              = 60
+  threshold           = 90
+  statistic           = "Average"
+
+  dimensions = {
+    DBInstanceIdentifier = var.rds_instance_id
+  }
+
+  alarm_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  ok_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  insufficient_data_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_storage" {
+  alarm_name          = "${var.rds_instance_id}-storage"
+  alarm_description   = "RDS Database storage space has been >90% full for over a minute"
+  comparison_operator = "LessThanThreshold"
+  metric_name         = "FreeStorageSpace"
+  namespace           = "AWS/RDS"
+  evaluation_periods  = 1
+  period              = 60
+  threshold           = var.rds_instance_allocated_storage * 0.1
+  statistic           = "Minimum"
+
+  dimensions = {
+    DBInstanceIdentifier = var.rds_instance_id
+  }
+
+  alarm_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  ok_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  insufficient_data_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+}
+
+resource "aws_cloudwatch_metric_alarm" "elasticache_cpu_usage" {
+  for_each = var.elasticache_node_ids
+
+  alarm_name          = "${each.value}-cpu-usage"
+  alarm_description   = "ElastiCache CPU utilization has been >90% for over a minute"
+  comparison_operator = "GreaterThanThreshold"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ElastiCache"
+  evaluation_periods  = 1
+  period              = 60
+  threshold           = 90
+  statistic           = "Average"
+
+  dimensions = {
+    CacheClusterId = var.elasticache_cluster_id
+    CacheNodeId    = each.value
+  }
+
+  alarm_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  ok_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  insufficient_data_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+}
+
+resource "aws_cloudwatch_metric_alarm" "elasticache_memory_usage" {
+  alarm_name          = "${var.elasticache_cluster_id}-memory-usage"
+  alarm_description   = "Elasticache memory usage has been >90% for over a minute"
+  comparison_operator = "GreaterThanThreshold"
+  metric_name         = "DatabaseMemoryUsagePercentage"
+  namespace           = "AWS/ElastiCache"
+  evaluation_periods  = 1
+  period              = 60
+  threshold           = 90
+  statistic           = "Average"
+
+  dimensions = {
+    CacheClusterId = var.elasticache_cluster_id
+  }
+
+  alarm_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  ok_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  insufficient_data_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
+  alarm_name          = "${var.alb_arn_suffix}-5xx-errors"
+  alarm_description   = "There have been >100 5xx responses at the ALB in a minute"
+  comparison_operator = "GreaterThanThreshold"
+  metric_name         = "HTTPCode_ELB_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  evaluation_periods  = 1
+  period              = 60
+  threshold           = 100
+  statistic           = "Sum"
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+  }
+
+  alarm_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  ok_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  insufficient_data_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_4xx_errors" {
+  alarm_name          = "${var.alb_arn_suffix}-4xx-errors"
+  alarm_description   = "There have been >100 4xx responses at the ALB in a minute"
+  comparison_operator = "GreaterThanThreshold"
+  metric_name         = "HTTPCode_ELB_4XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  evaluation_periods  = 1
+  period              = 60
+  threshold           = 100
+  statistic           = "Sum"
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+  }
+
+  alarm_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  ok_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  insufficient_data_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+}
+
+resource "aws_cloudwatch_metric_alarm" "alb_no_healthy_hosts" {
+  alarm_name          = "${var.alb_arn_suffix}-no-healthy-hosts"
+  alarm_description   = "There have been no healthy ALB hosts for over a minute"
+  comparison_operator = "LessThanThreshold"
+  metric_name         = "HealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  evaluation_periods  = 1
+  period              = 60
+  threshold           = 1
+  statistic           = "Minimum"
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+    TargetGroup  = var.alb_target_group_arn
+  }
+
+  alarm_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  ok_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  insufficient_data_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+}
+
+resource "aws_cloudwatch_metric_alarm" "waf_blocked_requests" {
+  alarm_name          = "${var.waf_acl_name}-blocked-requests"
+  alarm_description   = "There have been >100 blocked WAF requests in a minute"
+  comparison_operator = "GreaterThanThreshold"
+  metric_name         = "BlockedRequests"
+  namespace           = "AWS/WAFV2"
+  evaluation_periods  = 1
+  period              = 60
+  threshold           = 100
+  statistic           = "Sum"
+
+  dimensions = {
+    Rule  = "ALL"
+    WebACL = var.waf_acl_name
+  }
+
+  alarm_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  ok_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+  insufficient_data_actions = [
+    aws_sns_topic.alarm_sns_topic.arn,
+  ]
+}

--- a/terraform/modules/monitoring/resource_alarms.tf
+++ b/terraform/modules/monitoring/resource_alarms.tf
@@ -266,7 +266,7 @@ resource "aws_cloudwatch_metric_alarm" "waf_blocked_requests" {
   statistic           = "Sum"
 
   dimensions = {
-    Rule  = "ALL"
+    Rule   = "ALL"
     WebACL = var.waf_acl_name
   }
 

--- a/terraform/modules/monitoring/resource_alarms.tf
+++ b/terraform/modules/monitoring/resource_alarms.tf
@@ -17,12 +17,6 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpu_usage" {
   alarm_actions = [
     aws_sns_topic.alarm_sns_topic.arn,
   ]
-  ok_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
-  insufficient_data_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
 }
 
 resource "aws_cloudwatch_metric_alarm" "ecs_memory_usage" {
@@ -42,12 +36,6 @@ resource "aws_cloudwatch_metric_alarm" "ecs_memory_usage" {
   }
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
-  ok_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
-  insufficient_data_actions = [
     aws_sns_topic.alarm_sns_topic.arn,
   ]
 }
@@ -86,12 +74,6 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu_usage" {
   alarm_actions = [
     aws_sns_topic.alarm_sns_topic.arn,
   ]
-  ok_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
-  insufficient_data_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
 }
 
 resource "aws_cloudwatch_metric_alarm" "rds_storage" {
@@ -110,12 +92,6 @@ resource "aws_cloudwatch_metric_alarm" "rds_storage" {
   }
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
-  ok_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
-  insufficient_data_actions = [
     aws_sns_topic.alarm_sns_topic.arn,
   ]
 }
@@ -141,12 +117,6 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_cpu_usage" {
   alarm_actions = [
     aws_sns_topic.alarm_sns_topic.arn,
   ]
-  ok_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
-  insufficient_data_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
 }
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_memory_usage" {
@@ -165,12 +135,6 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_memory_usage" {
   }
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
-  ok_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
-  insufficient_data_actions = [
     aws_sns_topic.alarm_sns_topic.arn,
   ]
 }
@@ -193,12 +157,6 @@ resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
   alarm_actions = [
     aws_sns_topic.alarm_sns_topic.arn,
   ]
-  ok_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
-  insufficient_data_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
 }
 
 resource "aws_cloudwatch_metric_alarm" "alb_4xx_errors" {
@@ -217,12 +175,6 @@ resource "aws_cloudwatch_metric_alarm" "alb_4xx_errors" {
   }
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
-  ok_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
-  insufficient_data_actions = [
     aws_sns_topic.alarm_sns_topic.arn,
   ]
 }
@@ -246,12 +198,6 @@ resource "aws_cloudwatch_metric_alarm" "alb_no_healthy_hosts" {
   alarm_actions = [
     aws_sns_topic.alarm_sns_topic.arn,
   ]
-  ok_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
-  insufficient_data_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
 }
 
 resource "aws_cloudwatch_metric_alarm" "waf_blocked_requests" {
@@ -271,12 +217,6 @@ resource "aws_cloudwatch_metric_alarm" "waf_blocked_requests" {
   }
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
-  ok_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
-  ]
-  insufficient_data_actions = [
     aws_sns_topic.alarm_sns_topic.arn,
   ]
 }

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -16,3 +16,48 @@ variable "cloudwatch_log_expiration_days" {
   type        = number
   description = "Number of days to retain cloudwatch logs for"
 }
+
+variable "ecs_cluster_name" {
+    description = "Name of ECS cluster to create alarms for"
+    type        = string
+}
+
+variable "ecs_service_name" {
+    description = "Name of ECS service to create alarms for"
+    type        = string
+}
+
+variable "rds_instance_id" {
+    description = "ID of RDS instance to create alarms for"
+    type        = string
+}
+
+variable "rds_instance_allocated_storage" {
+    description = "Allocated storage of RDS instance to create alarms for"
+    type        = number
+}
+
+variable "elasticache_cluster_id" {
+    description = "ID of ElastiCache cluster to create alarms for"
+    type        = string
+}
+
+variable "elasticache_node_ids" {
+    description = "IDs of ElastiCache nodes to create alarms for"
+    type        = set(string)
+}
+
+variable "alb_arn_suffix" {
+    description = "ARN suffix of ALB to create alarms for"
+    type        = string
+}
+
+variable "alb_target_group_arn" {
+    description = "Target group ARN of ALB to create alarms for"
+    type        = string
+}
+
+variable "waf_acl_name" {
+  description = "Name of WAF web ACL to create alarms for"
+  type = string
+}

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -18,46 +18,46 @@ variable "cloudwatch_log_expiration_days" {
 }
 
 variable "ecs_cluster_name" {
-    description = "Name of ECS cluster to create alarms for"
-    type        = string
+  description = "Name of ECS cluster to create alarms for"
+  type        = string
 }
 
 variable "ecs_service_name" {
-    description = "Name of ECS service to create alarms for"
-    type        = string
+  description = "Name of ECS service to create alarms for"
+  type        = string
 }
 
 variable "rds_instance_id" {
-    description = "ID of RDS instance to create alarms for"
-    type        = string
+  description = "ID of RDS instance to create alarms for"
+  type        = string
 }
 
 variable "rds_instance_allocated_storage" {
-    description = "Allocated storage of RDS instance to create alarms for"
-    type        = number
+  description = "Allocated storage of RDS instance to create alarms for"
+  type        = number
 }
 
 variable "elasticache_cluster_id" {
-    description = "ID of ElastiCache cluster to create alarms for"
-    type        = string
+  description = "ID of ElastiCache cluster to create alarms for"
+  type        = string
 }
 
 variable "elasticache_node_ids" {
-    description = "IDs of ElastiCache nodes to create alarms for"
-    type        = set(string)
+  description = "IDs of ElastiCache nodes to create alarms for"
+  type        = set(string)
 }
 
 variable "alb_arn_suffix" {
-    description = "ARN suffix of ALB to create alarms for"
-    type        = string
+  description = "ARN suffix of ALB to create alarms for"
+  type        = string
 }
 
 variable "alb_target_group_arn" {
-    description = "Target group ARN of ALB to create alarms for"
-    type        = string
+  description = "Target group ARN of ALB to create alarms for"
+  type        = string
 }
 
 variable "waf_acl_name" {
   description = "Name of WAF web ACL to create alarms for"
-  type = string
+  type        = string
 }

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -12,3 +12,8 @@ output "database_url_ssm_parameter_arn" {
   value       = aws_ssm_parameter.database_url.arn
   description = "The ARN of the SSM parameter containing the database URL"
 }
+
+output "rds_instance_id" {
+  value       = aws_db_instance.main.id
+  description = "The ID of the RDS instance"
+}

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -39,6 +39,7 @@ locals {
   load_balancer_domain_name = "${local.environment_name}.lb.register-home-to-rent.test.communities.gov.uk"
 
   cloudwatch_log_expiration_days = 60
+  database_allocated_storage     = 50
 }
 
 module "networking" {
@@ -162,7 +163,7 @@ module "database" {
   environment_name                = local.environment_name
   database_password               = module.secrets.database_password.result
   database_port                   = local.database_port
-  allocated_storage               = 50
+  allocated_storage               = local.database_allocated_storage
   backup_retention_period         = 7
   db_subnet_group_name            = module.networking.db_subnet_group_name
   instance_class                  = "db.t4g.small"
@@ -219,4 +220,13 @@ module "monitoring" {
   environment_name               = local.environment_name
   cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
   alarm_email_address            = var.alarm_email_address
+  alb_arn_suffix                 = module.frontdoor.load_balancer.arn_suffix
+  alb_target_group_arn           = module.frontdoor.load_balancer.target_group_arn
+  ecs_cluster_name               = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
+  ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
+  elasticache_cluster_id         = module.redis.redis_cluster_id
+  elasticache_node_ids           = toset(module.redis.redis_node_ids)
+  rds_instance_allocated_storage = local.database_allocated_storage
+  rds_instance_id                = module.database.rds_instance_id
+  waf_acl_name                   = module.frontdoor.waf_acl_name
 }


### PR DESCRIPTION
## Ticket number

PRSD-1526

## Goal of change

Adds CloudWatch alarms for resource metrics

## Description of main change(s)

- Created CloudWatch alarms for:
  - High ECS CPU usage
  - High ECS memory usage
  - ECS task failing to start (also added corresponding log group and metric)
  - High RDS instance CPU usage
  - Low RDS storage space
  - High Elasticache CPU usage
  - Low Elasticache storage space
  - Persistent 5xx codes reaching the ALB
  - Persistent 4xx codes reaching the ALB
  - No healthy ALB hosts
  - Persistent WAF block actions

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist
Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done