### PR TITLE
PRSD-1526: Fix and Clean-up CloudWatch Alarms

### DIFF
--- a/terraform/environment_template/main.tf.template
+++ b/terraform/environment_template/main.tf.template
@@ -207,6 +207,10 @@ module "file_upload" {
 module "monitoring" {
   source = "../modules/monitoring"
 
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
+
   environment_name               = local.environment_name
   cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
   alarm_email_address            = var.alarm_email_address

--- a/terraform/environment_template/main.tf.template
+++ b/terraform/environment_template/main.tf.template
@@ -216,7 +216,7 @@ module "monitoring" {
   ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
   elasticache_cluster_id         = module.redis.redis_cluster_id
   elasticache_node_ids           = toset(module.redis.redis_node_ids)
-  rds_instance_allocated_storage = local.database_allocated_storage
-  rds_instance_id                = module.database.rds_instance_id
+  database_allocated_storage     = local.database_allocated_storage
+  database_identifier            = module.database.database_identifier
   waf_acl_name                   = module.frontdoor.waf_acl_name
 }

--- a/terraform/environment_template/main.tf.template
+++ b/terraform/environment_template/main.tf.template
@@ -214,8 +214,7 @@ module "monitoring" {
   alb_target_group_arn           = module.frontdoor.load_balancer.target_group_arn
   ecs_cluster_name               = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
   ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
-  elasticache_cluster_id         = module.redis.redis_cluster_id
-  elasticache_node_ids           = toset(module.redis.redis_node_ids)
+  elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)
   database_allocated_storage     = local.database_allocated_storage
   database_identifier            = module.database.database_identifier
   waf_acl_name                   = module.frontdoor.waf_acl_name

--- a/terraform/environment_template/main.tf.template
+++ b/terraform/environment_template/main.tf.template
@@ -210,8 +210,9 @@ module "monitoring" {
   environment_name               = local.environment_name
   cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
   alarm_email_address            = var.alarm_email_address
+  alb_name                       = module.frontdoor.load_balancer.name
   alb_arn_suffix                 = module.frontdoor.load_balancer.arn_suffix
-  alb_target_group_arn           = module.frontdoor.load_balancer.target_group_arn
+  alb_target_group_arn_suffix    = module.frontdoor.load_balancer.target_group_arn_suffix
   ecs_cluster_name               = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
   ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
   elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -220,8 +220,9 @@ module "monitoring" {
   environment_name               = local.environment_name
   cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
   alarm_email_address            = var.alarm_email_address
+  alb_name                       = module.frontdoor.load_balancer.name
   alb_arn_suffix                 = module.frontdoor.load_balancer.arn_suffix
-  alb_target_group_arn           = module.frontdoor.load_balancer.target_group_arn
+  alb_target_group_arn_suffix    = module.frontdoor.load_balancer.target_group_arn_suffix
   ecs_cluster_name               = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
   ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
   elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -226,7 +226,7 @@ module "monitoring" {
   ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
   elasticache_cluster_id         = module.redis.redis_cluster_id
   elasticache_node_ids           = toset(module.redis.redis_node_ids)
-  rds_instance_allocated_storage = local.database_allocated_storage
-  rds_instance_id                = module.database.rds_instance_id
+  database_allocated_storage     = local.database_allocated_storage
+  database_identifier            = module.database.database_identifier
   waf_acl_name                   = module.frontdoor.waf_acl_name
 }

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -224,8 +224,7 @@ module "monitoring" {
   alb_target_group_arn           = module.frontdoor.load_balancer.target_group_arn
   ecs_cluster_name               = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
   ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
-  elasticache_cluster_id         = module.redis.redis_cluster_id
-  elasticache_node_ids           = toset(module.redis.redis_node_ids)
+  elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)
   database_allocated_storage     = local.database_allocated_storage
   database_identifier            = module.database.database_identifier
   waf_acl_name                   = module.frontdoor.waf_acl_name

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -217,6 +217,10 @@ module "file_upload" {
 module "monitoring" {
   source = "../modules/monitoring"
 
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
+
   environment_name               = local.environment_name
   cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
   alarm_email_address            = var.alarm_email_address

--- a/terraform/modules/elasticache/outputs.tf
+++ b/terraform/modules/elasticache/outputs.tf
@@ -3,12 +3,7 @@ output "redis_security_group_id" {
   description = "ID for the security group for redis"
 }
 
-output "redis_cluster_id" {
-  value       = aws_elasticache_replication_group.main.id
-  description = "ID of the redis cluster"
-}
-
-output "redis_node_ids" {
+output "redis_cluster_ids" {
   value       = aws_elasticache_replication_group.main.member_clusters
-  description = "IDs of the redis nodes"
+  description = "IDs of the redis clusters"
 }

--- a/terraform/modules/frontdoor/outputs.tf
+++ b/terraform/modules/frontdoor/outputs.tf
@@ -1,12 +1,14 @@
 output "load_balancer" {
   description = "An object representing the application load balancer"
   value = {
-    arn               = aws_lb.main.arn
-    arn_suffix        = aws_lb.main.arn_suffix
-    dns_name          = aws_lb.main.dns_name
-    listener_arn      = var.ssl_certs_created ? aws_lb_listener.https[0].arn : null
-    security_group_id = aws_security_group.load_balancer.id
-    target_group_arn  = aws_lb_target_group.main.arn
+    name                    = aws_lb.main.name
+    arn                     = aws_lb.main.arn
+    arn_suffix              = aws_lb.main.arn_suffix
+    dns_name                = aws_lb.main.dns_name
+    listener_arn            = var.ssl_certs_created ? aws_lb_listener.https[0].arn : null
+    security_group_id       = aws_security_group.load_balancer.id
+    target_group_arn        = aws_lb_target_group.main.arn
+    target_group_arn_suffix = aws_lb_target_group.main.arn_suffix
   }
 }
 

--- a/terraform/modules/monitoring/cloudwatch.tf
+++ b/terraform/modules/monitoring/cloudwatch.tf
@@ -3,19 +3,68 @@ resource "aws_cloudwatch_event_rule" "ecs_events" {
   description = "Capture ECS events"
 
   event_pattern = jsonencode({
-    "source" : ["aws.ecs"],
+    source : ["aws.ecs"],
   })
 }
 
 module "ecs_events_log_group" {
   source = "../encrypted_log_group"
 
-  log_group_name     = "${var.environment_name}-ecs-events"
+  log_group_name     = "/aws/events/ecs/${var.environment_name}-ecs-events"
   log_retention_days = 1
 }
 
+data "aws_iam_policy_document" "ecs_events_log_policy_document" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream"
+    ]
+
+    resources = [
+      "${module.ecs_events_log_group.log_group_arn}:*"
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "events.amazonaws.com",
+        "delivery.logs.amazonaws.com"
+      ]
+    }
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:PutLogEvents"
+    ]
+
+    resources = [
+      "${module.ecs_events_log_group.log_group_arn}:*:*"
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "events.amazonaws.com",
+        "delivery.logs.amazonaws.com"
+      ]
+    }
+
+    condition {
+      test     = "ArnEquals"
+      values   = [aws_cloudwatch_event_rule.ecs_events.arn]
+      variable = "aws:SourceArn"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_resource_policy" "ecs_events_log_policy" {
+  policy_document = data.aws_iam_policy_document.ecs_events_log_policy_document.json
+  policy_name     = "ecs-events-log-policy"
+}
+
 resource "aws_cloudwatch_event_target" "ecs_events_to_logs" {
-  target_id = "${var.environment_name}-ecs-events-to-logs"
-  rule      = aws_cloudwatch_event_rule.ecs_events.name
-  arn       = module.ecs_events_log_group.log_group_arn
+  rule = aws_cloudwatch_event_rule.ecs_events.name
+  arn  = module.ecs_events_log_group.log_group_arn
 }

--- a/terraform/modules/monitoring/cloudwatch.tf
+++ b/terraform/modules/monitoring/cloudwatch.tf
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_event_rule" "ecs_events" {
 module "ecs_events_log_group" {
   source = "../encrypted_log_group"
 
-  log_group_name     = "/aws/events/ecs/${var.environment_name}-ecs-events"
+  log_group_name     = "${var.environment_name}-ecs-events"
   log_retention_days = 1
 }
 

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -3,8 +3,9 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~>5.0"
+      source                = "hashicorp/aws"
+      version               = "~>5.0"
+      configuration_aliases = [aws.us-east-1]
     }
   }
 }

--- a/terraform/modules/monitoring/metrics.tf
+++ b/terraform/modules/monitoring/metrics.tf
@@ -18,7 +18,7 @@ resource "aws_cloudwatch_log_metric_filter" "unauthorized_api_calls" {
   pattern        = <<EOT
     {(($.errorCode = UnauthorizedOperation) ||
       ($.errorCode = AccessDenied)) &&
-     ($.userIdentity.sessionContext.sessionIssuer.userName != "WizAccess-Role")}
+     ($.userIdentity.sessionContext.sessionIssuer.arn != "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/WizAccess-Role")}
   EOT
 
   metric_transformation {

--- a/terraform/modules/monitoring/metrics.tf
+++ b/terraform/modules/monitoring/metrics.tf
@@ -16,8 +16,9 @@ resource "aws_cloudwatch_log_metric_filter" "unauthorized_api_calls" {
   log_group_name = module.cloudtrail_cloudwatch_group.name
   name           = "unauthorized-api-calls-${var.environment_name}"
   pattern        = <<EOT
-    {($.errorCode = UnauthorizedOperation) ||
-     ($.errorCode = AccessDenied)}
+    {(($.errorCode = UnauthorizedOperation) ||
+      ($.errorCode = AccessDenied)) &&
+     ($.userIdentity.sessionContext.sessionIssuer.userName != "WizAccess-Role")}
   EOT
 
   metric_transformation {

--- a/terraform/modules/monitoring/resource_alarms.tf
+++ b/terraform/modules/monitoring/resource_alarms.tf
@@ -44,7 +44,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_task_start_failure" {
   alarm_name          = "${var.ecs_service_name}-ecs-task-start-failure"
   alarm_description   = "An ECS task has failed to start and reach a healthy state"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  metric_name         = "ecs_task_start_failure"
+  metric_name         = aws_cloudwatch_log_metric_filter.ecs_task_start_failure.name
   namespace           = "LogMetrics"
   evaluation_periods  = 1
   period              = 60

--- a/terraform/modules/monitoring/resource_alarms.tf
+++ b/terraform/modules/monitoring/resource_alarms.tf
@@ -57,7 +57,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_task_start_failure" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "rds_cpu_usage" {
-  alarm_name          = "${var.rds_instance_id}-cpu-usage"
+  alarm_name          = "${var.database_identifier}-cpu-usage"
   alarm_description   = "RDS Database CPU utilization has been >90% for over a minute"
   comparison_operator = "GreaterThanThreshold"
   metric_name         = "CPUUtilization"
@@ -68,7 +68,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu_usage" {
   statistic           = "Average"
 
   dimensions = {
-    DBInstanceIdentifier = var.rds_instance_id
+    DBInstanceIdentifier = var.database_identifier
   }
 
   alarm_actions = [
@@ -77,18 +77,18 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu_usage" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "rds_storage" {
-  alarm_name          = "${var.rds_instance_id}-storage"
+  alarm_name          = "${var.database_identifier}-storage"
   alarm_description   = "RDS Database storage space has been >90% full for over a minute"
   comparison_operator = "LessThanThreshold"
   metric_name         = "FreeStorageSpace"
   namespace           = "AWS/RDS"
   evaluation_periods  = 1
   period              = 60
-  threshold           = var.rds_instance_allocated_storage * 0.1
+  threshold           = var.database_allocated_storage * 0.1
   statistic           = "Minimum"
 
   dimensions = {
-    DBInstanceIdentifier = var.rds_instance_id
+    DBInstanceIdentifier = var.database_identifier
   }
 
   alarm_actions = [

--- a/terraform/modules/monitoring/resource_alarms.tf
+++ b/terraform/modules/monitoring/resource_alarms.tf
@@ -50,6 +50,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_task_start_failure" {
   period              = 60
   threshold           = 1
   statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
 
   alarm_actions = [
     aws_sns_topic.alarm_sns_topic.arn,
@@ -150,6 +151,7 @@ resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
   period              = 60
   threshold           = 100
   statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     LoadBalancer = var.alb_arn_suffix
@@ -170,6 +172,7 @@ resource "aws_cloudwatch_metric_alarm" "alb_4xx_errors" {
   period              = 60
   threshold           = 100
   statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     LoadBalancer = var.alb_arn_suffix
@@ -211,6 +214,7 @@ resource "aws_cloudwatch_metric_alarm" "waf_blocked_requests" {
   period              = 60
   threshold           = 100
   statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
   provider            = aws.us-east-1
 
   dimensions = {

--- a/terraform/modules/monitoring/resource_alarms.tf
+++ b/terraform/modules/monitoring/resource_alarms.tf
@@ -211,6 +211,7 @@ resource "aws_cloudwatch_metric_alarm" "waf_blocked_requests" {
   period              = 60
   threshold           = 100
   statistic           = "Sum"
+  provider            = aws.us-east-1
 
   dimensions = {
     Rule   = "ALL"
@@ -218,6 +219,6 @@ resource "aws_cloudwatch_metric_alarm" "waf_blocked_requests" {
   }
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.us_alarm_sns_topic.arn,
   ]
 }

--- a/terraform/modules/monitoring/resource_alarms.tf
+++ b/terraform/modules/monitoring/resource_alarms.tf
@@ -141,10 +141,10 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_memory_usage" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
-  alarm_name          = "${var.alb_arn_suffix}-5xx-errors"
+  alarm_name          = "${var.alb_name}-5xx-errors"
   alarm_description   = "There have been >100 5xx responses at the ALB in a minute"
   comparison_operator = "GreaterThanThreshold"
-  metric_name         = "HTTPCode_ELB_5XX_Count"
+  metric_name         = "HTTPCode_Target_5XX_Count"
   namespace           = "AWS/ApplicationELB"
   evaluation_periods  = 1
   period              = 60
@@ -161,10 +161,10 @@ resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "alb_4xx_errors" {
-  alarm_name          = "${var.alb_arn_suffix}-4xx-errors"
+  alarm_name          = "${var.alb_name}-4xx-errors"
   alarm_description   = "There have been >100 4xx responses at the ALB in a minute"
   comparison_operator = "GreaterThanThreshold"
-  metric_name         = "HTTPCode_ELB_4XX_Count"
+  metric_name         = "HTTPCode_Target_4XX_Count"
   namespace           = "AWS/ApplicationELB"
   evaluation_periods  = 1
   period              = 60
@@ -181,7 +181,7 @@ resource "aws_cloudwatch_metric_alarm" "alb_4xx_errors" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "alb_no_healthy_hosts" {
-  alarm_name          = "${var.alb_arn_suffix}-no-healthy-hosts"
+  alarm_name          = "${var.alb_name}-no-healthy-hosts"
   alarm_description   = "There have been no healthy ALB hosts for over a minute"
   comparison_operator = "LessThanThreshold"
   metric_name         = "HealthyHostCount"
@@ -193,7 +193,7 @@ resource "aws_cloudwatch_metric_alarm" "alb_no_healthy_hosts" {
 
   dimensions = {
     LoadBalancer = var.alb_arn_suffix
-    TargetGroup  = var.alb_target_group_arn
+    TargetGroup  = var.alb_target_group_arn_suffix
   }
 
   alarm_actions = [

--- a/terraform/modules/monitoring/resource_alarms.tf
+++ b/terraform/modules/monitoring/resource_alarms.tf
@@ -97,7 +97,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_storage" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_cpu_usage" {
-  for_each = var.elasticache_node_ids
+  for_each = var.elasticache_cluster_ids
 
   alarm_name          = "${each.value}-cpu-usage"
   alarm_description   = "ElastiCache CPU utilization has been >90% for over a minute"
@@ -110,8 +110,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_cpu_usage" {
   statistic           = "Average"
 
   dimensions = {
-    CacheClusterId = var.elasticache_cluster_id
-    CacheNodeId    = each.value
+    CacheClusterId = each.value
   }
 
   alarm_actions = [
@@ -120,8 +119,10 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_cpu_usage" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "elasticache_memory_usage" {
-  alarm_name          = "${var.elasticache_cluster_id}-memory-usage"
-  alarm_description   = "Elasticache memory usage has been >90% for over a minute"
+  for_each = var.elasticache_cluster_ids
+
+  alarm_name          = "${each.value}-memory-usage"
+  alarm_description   = "ElastiCache memory usage has been >90% for over a minute"
   comparison_operator = "GreaterThanThreshold"
   metric_name         = "DatabaseMemoryUsagePercentage"
   namespace           = "AWS/ElastiCache"
@@ -131,7 +132,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_memory_usage" {
   statistic           = "Average"
 
   dimensions = {
-    CacheClusterId = var.elasticache_cluster_id
+    CacheClusterId = each.value
   }
 
   alarm_actions = [

--- a/terraform/modules/monitoring/sns.tf
+++ b/terraform/modules/monitoring/sns.tf
@@ -10,3 +10,16 @@ resource "aws_sns_topic_subscription" "alarm_email_subscription" {
   protocol  = "email"
   endpoint  = var.alarm_email_address
 }
+
+resource "aws_sns_topic" "us_alarm_sns_topic" {
+  name         = "${var.environment_name}-us-alarm-sns-topic"
+  display_name = "Notifications for cloudwatch alarms in ${var.environment_name} environment and us-east-1 region"
+  provider     = aws.us-east-1
+}
+
+resource "aws_sns_topic_subscription" "us_alarm_email_subscription" {
+  topic_arn = aws_sns_topic.us_alarm_sns_topic.arn
+  protocol  = "email"
+  endpoint  = var.alarm_email_address
+  provider  = aws.us-east-1
+}

--- a/terraform/modules/monitoring/sns.tf
+++ b/terraform/modules/monitoring/sns.tf
@@ -11,6 +11,8 @@ resource "aws_sns_topic_subscription" "alarm_email_subscription" {
   endpoint  = var.alarm_email_address
 }
 
+# non-sensitive
+# tfsec:ignore:aws-sns-enable-topic-encryption
 resource "aws_sns_topic" "us_alarm_sns_topic" {
   name         = "${var.environment_name}-us-alarm-sns-topic"
   display_name = "Notifications for cloudwatch alarms in ${var.environment_name} environment and us-east-1 region"

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -37,13 +37,8 @@ variable "database_allocated_storage" {
   type        = number
 }
 
-variable "elasticache_cluster_id" {
-  description = "ID of ElastiCache cluster to create alarms for"
-  type        = string
-}
-
-variable "elasticache_node_ids" {
-  description = "IDs of ElastiCache nodes to create alarms for"
+variable "elasticache_cluster_ids" {
+  description = "IDs of ElastiCache clusters to create alarms for"
   type        = set(string)
 }
 

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -42,13 +42,18 @@ variable "elasticache_cluster_ids" {
   type        = set(string)
 }
 
+variable "alb_name" {
+  description = "Name of ALB to create alarms for"
+  type        = string
+}
+
 variable "alb_arn_suffix" {
   description = "ARN suffix of ALB to create alarms for"
   type        = string
 }
 
-variable "alb_target_group_arn" {
-  description = "Target group ARN of ALB to create alarms for"
+variable "alb_target_group_arn_suffix" {
+  description = "ARN suffix of target group of ALB to create alarms for"
   type        = string
 }
 

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -27,12 +27,12 @@ variable "ecs_service_name" {
   type        = string
 }
 
-variable "rds_instance_id" {
-  description = "ID of RDS instance to create alarms for"
+variable "database_identifier" {
+  description = "Identifier of DB instance to create alarms for"
   type        = string
 }
 
-variable "rds_instance_allocated_storage" {
+variable "database_allocated_storage" {
   description = "Allocated storage of RDS instance to create alarms for"
   type        = number
 }

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -13,7 +13,7 @@ output "database_url_ssm_parameter_arn" {
   description = "The ARN of the SSM parameter containing the database URL"
 }
 
-output "rds_instance_id" {
-  value       = aws_db_instance.main.id
-  description = "The ID of the RDS instance"
+output "database_identifier" {
+  value       = aws_db_instance.main.identifier
+  description = "The identifier of the DB instance"
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -218,8 +218,9 @@ module "monitoring" {
   environment_name               = local.environment_name
   cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
   alarm_email_address            = var.alarm_email_address
+  alb_name                       = module.frontdoor.load_balancer.name
   alb_arn_suffix                 = module.frontdoor.load_balancer.arn_suffix
-  alb_target_group_arn           = module.frontdoor.load_balancer.target_group_arn
+  alb_target_group_arn_suffix    = module.frontdoor.load_balancer.target_group_arn_suffix
   ecs_cluster_name               = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
   ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
   elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -222,8 +222,7 @@ module "monitoring" {
   alb_target_group_arn           = module.frontdoor.load_balancer.target_group_arn
   ecs_cluster_name               = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
   ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
-  elasticache_cluster_id         = module.redis.redis_cluster_id
-  elasticache_node_ids           = toset(module.redis.redis_node_ids)
+  elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)
   database_allocated_storage     = local.database_allocated_storage
   database_identifier            = module.database.database_identifier
   waf_acl_name                   = module.frontdoor.waf_acl_name

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -224,7 +224,7 @@ module "monitoring" {
   ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
   elasticache_cluster_id         = module.redis.redis_cluster_id
   elasticache_node_ids           = toset(module.redis.redis_node_ids)
-  rds_instance_allocated_storage = local.database_allocated_storage
-  rds_instance_id                = module.database.rds_instance_id
+  database_allocated_storage     = local.database_allocated_storage
+  database_identifier            = module.database.database_identifier
   waf_acl_name                   = module.frontdoor.waf_acl_name
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -215,6 +215,10 @@ module "file_upload" {
 module "monitoring" {
   source = "../modules/monitoring"
 
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
+
   environment_name               = local.environment_name
   cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
   alarm_email_address            = var.alarm_email_address

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -220,8 +220,9 @@ module "monitoring" {
   environment_name               = local.environment_name
   cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
   alarm_email_address            = var.alarm_email_address
+  alb_name                       = module.frontdoor.load_balancer.name
   alb_arn_suffix                 = module.frontdoor.load_balancer.arn_suffix
-  alb_target_group_arn           = module.frontdoor.load_balancer.target_group_arn
+  alb_target_group_arn_suffix    = module.frontdoor.load_balancer.target_group_arn_suffix
   ecs_cluster_name               = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
   ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
   elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -226,7 +226,7 @@ module "monitoring" {
   ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
   elasticache_cluster_id         = module.redis.redis_cluster_id
   elasticache_node_ids           = toset(module.redis.redis_node_ids)
-  rds_instance_allocated_storage = local.database_allocated_storage
-  rds_instance_id                = module.database.rds_instance_id
+  database_allocated_storage     = local.database_allocated_storage
+  database_identifier            = module.database.database_identifier
   waf_acl_name                   = module.frontdoor.waf_acl_name
 }

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -224,8 +224,7 @@ module "monitoring" {
   alb_target_group_arn           = module.frontdoor.load_balancer.target_group_arn
   ecs_cluster_name               = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
   ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
-  elasticache_cluster_id         = module.redis.redis_cluster_id
-  elasticache_node_ids           = toset(module.redis.redis_node_ids)
+  elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)
   database_allocated_storage     = local.database_allocated_storage
   database_identifier            = module.database.database_identifier
   waf_acl_name                   = module.frontdoor.waf_acl_name

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -217,6 +217,10 @@ module "file_upload" {
 module "monitoring" {
   source = "../modules/monitoring"
 
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
+
   environment_name               = local.environment_name
   cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
   alarm_email_address            = var.alarm_email_address


### PR DESCRIPTION
## Ticket number

PRSD-1526

## Goal of change

Fixes and cleans up CloudWatch alarms

## Description of main change(s)

- Fixes incorrect CloudWatch alarm config
- Adds `WizAccess-Role` exemption to alarm for unauthorized API calls
- Treats missing data as ok when appropriate (e.g. when counting errors)

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist
Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done