### PR TITLE
PRSD-1537: Creates update ECS service workflow

### DIFF
--- a/.github/workflows/update-ecs-service.yml
+++ b/.github/workflows/update-ecs-service.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: "arn:aws:iam::${{ inputs.account_id }}:role/github-actions-terraform-admin"
-          aws-region: "eu-west-2"
+          role-to-assume: arn:aws:iam::${{ inputs.account_id }}:role/github-actions-terraform-admin
+          aws-region: eu-west-2
 
       - name: Update ECS service
         run: aws ecs update-service --cluster ${{ inputs.environment }}-app --service ${{ inputs.environment }}-app --task-definition prsdb-webapp-${{ inputs.environment }} --force-new-deployment

--- a/.github/workflows/update-ecs-service.yml
+++ b/.github/workflows/update-ecs-service.yml
@@ -1,0 +1,30 @@
+name: Update ECS service
+on:
+  workflow_call:
+    inputs:
+      environment_name:
+        description: 'The name of the environment to update the ECS service in'
+        type: string
+        required: true
+      account_id:
+        description: 'The id of the AWS account to update the ECS service in'
+        type: string
+        required: true
+
+jobs:
+  update-ecs-service:
+    name: Update ECS service
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: "arn:aws:iam::${{ inputs.account_id }}:role/github-actions-terraform-admin"
+          aws-region: "eu-west-2"
+
+      - name: Update ECS service
+        run: aws ecs update-service --cluster ${{ inputs.environment }}-app --service ${{ inputs.environment }}-app --task-definition prsdb-webapp-${{ inputs.environment }} --force-new-deployment
+


### PR DESCRIPTION
## Ticket number

PRSD-1537

## Goal of change

Creates GitHub workflow for updating the ECS service

## Description of main change(s)

As above

## Anything you'd like to highlight to the reviewer?

- An webapp PR will be created that refactors current workflows with 'update ECS service' jobs to call this workflow
- Although all current 'update ECS service' jobs are in the webapp repo, this ticket involves creating an infra pipeline that'll have one, so the workflow has been placed here

## Checklist
Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done