### PR TITLE
PRSD-1075: Add AWS Shield Advanced resource to terraform

### DIFF
--- a/terraform/modules/frontdoor/cloudfront.tf
+++ b/terraform/modules/frontdoor/cloudfront.tf
@@ -123,6 +123,10 @@ resource "aws_cloudfront_function" "url_rewriter" {
   code    = file("${path.module}/url_rewriter.js")
 }
 
+resource "aws_shield_subscription" "cloudfront" {
+  count = var.use_aws_shield_advanced ? 1 : 0
+}
+
 resource "aws_shield_protection" "cloudfront" {
   count = var.use_aws_shield_advanced ? 1 : 0
 


### PR DESCRIPTION
## Ticket number

PRSD-1075

## Goal of change

Add AWS Shield Advanced resource to terraform

## Description of main change(s)

As above

## Anything you'd like to highlight to the reviewer?

I *think* this is the last change to make AWS Shield Advanced work with cloudfront

## Checklist

N/A