### PR TITLE
PRSD-1075: Enable AWS Shield Advanced for cloudfront and load balancer on test

### DIFF
--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -86,7 +86,7 @@ module "frontdoor" {
     "4.158.35.41/32",
   ]
   cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
-  use_aws_shield_advanced        = false
+  use_aws_shield_advanced        = true
 }
 
 module "certificates" {


### PR DESCRIPTION
## Ticket number

PRSD-1075

## Goal of change

Enable AWS Shield Advanced for cloudfront and load balancer on test

## Description of main change(s)

As above

## Anything you'd like to highlight to the reviewer?

This PR should not be merged until the [PR](https://github.com/communitiesuk/prsdb-infra/pull/178) enabling the advanced shield on the load balancer on integration has been merged and works

## Checklist

N/A