### PR TITLE
PRSD-1075: Enable AWS Shield Advanced on production

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -86,7 +86,7 @@ module "frontdoor" {
   load_balancer_certificate_arn  = module.certificates.load_balancer_certificate_arn
   ip_allowlist                   = local.ip_allowlist
   cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
-  use_aws_shield_advanced        = false
+  use_aws_shield_advanced        = true
 }
 
 module "certificates" {


### PR DESCRIPTION
## Ticket number

PRSD-1075

## Goal of change

Enable AWS Shield Advanced for cloudfront and load balancer on production

## Description of main change(s)

As above

## Anything you'd like to highlight to the reviewer?

This PR should not be merged until the [PR](https://github.com/communitiesuk/prsdb-infra/pull/179) enabling the advanced shield on cloudfront and the load balancer on the test environment:
[ ] has been merged

## Checklist

N/A