### PR TITLE
PRSD-1021: Renames OS API key

### DIFF
--- a/terraform/environment_template/ecs_task_definition/data.tf.template
+++ b/terraform/environment_template/ecs_task_definition/data.tf.template
@@ -54,8 +54,8 @@ data "aws_secretsmanager_secret" "notify_api_key" {
   name = "tf-${local.environment_name}-notify-api-key"
 }
 
-data "aws_secretsmanager_secret" "os_places_api_key" {
-  name = "tf-${local.environment_name}-os-places-api-key"
+data "aws_secretsmanager_secret" "os_api_key" {
+  name = "tf-${local.environment_name}-os-api-key"
 }
 
 data "aws_ssm_parameter" "quarantine_bucket" {

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -138,8 +138,8 @@ locals {
       valueFrom = data.aws_secretsmanager_secret.notify_api_key.arn
     },
     {
-      name      = "OS_PLACES_API_KEY"
-      valueFrom = data.aws_secretsmanager_secret.os_places_api_key.arn
+      name      = "OS_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.os_api_key.arn
     },
     {
       name      = "EPC_REGISTER_CLIENT_SECRET"

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -54,8 +54,8 @@ data "aws_secretsmanager_secret" "notify_api_key" {
   name = "tf-${local.environment_name}-notify-api-key"
 }
 
-data "aws_secretsmanager_secret" "os_places_api_key" {
-  name = "tf-${local.environment_name}-os-places-api-key"
+data "aws_secretsmanager_secret" "os_api_key" {
+  name = "tf-${local.environment_name}-os-api-key"
 }
 
 data "aws_ssm_parameter" "quarantine_bucket" {

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -138,8 +138,8 @@ locals {
       valueFrom = data.aws_secretsmanager_secret.notify_api_key.arn
     },
     {
-      name      = "OS_PLACES_API_KEY"
-      valueFrom = data.aws_secretsmanager_secret.os_places_api_key.arn
+      name      = "OS_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.os_api_key.arn
     },
     {
       name      = "EPC_REGISTER_CLIENT_SECRET"

--- a/terraform/modules/secrets/iam.tf
+++ b/terraform/modules/secrets/iam.tf
@@ -47,7 +47,7 @@ resource "aws_iam_role_policy" "secret_access" {
           aws_secretsmanager_secret.redis_password.arn,
           aws_secretsmanager_secret.one_login_private_key.arn,
           aws_secretsmanager_secret.notify_api_key.arn,
-          aws_secretsmanager_secret.os_places_api_key.arn,
+          aws_secretsmanager_secret.os_api_key.arn,
           aws_secretsmanager_secret.epc_register_client_secret.arn,
         ]
       }

--- a/terraform/modules/secrets/secrets.tf
+++ b/terraform/modules/secrets/secrets.tf
@@ -46,9 +46,9 @@ resource "aws_secretsmanager_secret" "notify_api_key" {
   kms_key_id              = aws_kms_key.prsdb_webapp_secrets.arn
 }
 
-resource "aws_secretsmanager_secret" "os_places_api_key" {
-  name                    = "tf-${var.environment_name}-os-places-api-key"
-  description             = "API key for OS Places"
+resource "aws_secretsmanager_secret" "os_api_key" {
+  name                    = "tf-${var.environment_name}-os-api-key"
+  description             = "API key for OS"
   recovery_window_in_days = 0
   kms_key_id              = aws_kms_key.prsdb_webapp_secrets.arn
 }

--- a/terraform/production/ecs_task_definition/data.tf
+++ b/terraform/production/ecs_task_definition/data.tf
@@ -54,8 +54,8 @@ data "aws_secretsmanager_secret" "notify_api_key" {
   name = "tf-${local.environment_name}-notify-api-key"
 }
 
-data "aws_secretsmanager_secret" "os_places_api_key" {
-  name = "tf-${local.environment_name}-os-places-api-key"
+data "aws_secretsmanager_secret" "os_api_key" {
+  name = "tf-${local.environment_name}-os-api-key"
 }
 
 data "aws_ssm_parameter" "quarantine_bucket" {

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -138,8 +138,8 @@ locals {
       valueFrom = data.aws_secretsmanager_secret.notify_api_key.arn
     },
     {
-      name      = "OS_PLACES_API_KEY"
-      valueFrom = data.aws_secretsmanager_secret.os_places_api_key.arn
+      name      = "OS_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.os_api_key.arn
     },
     {
       name      = "EPC_REGISTER_CLIENT_SECRET"

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -54,8 +54,8 @@ data "aws_secretsmanager_secret" "notify_api_key" {
   name = "tf-${local.environment_name}-notify-api-key"
 }
 
-data "aws_secretsmanager_secret" "os_places_api_key" {
-  name = "tf-${local.environment_name}-os-places-api-key"
+data "aws_secretsmanager_secret" "os_api_key" {
+  name = "tf-${local.environment_name}-os-api-key"
 }
 
 data "aws_ssm_parameter" "quarantine_bucket" {

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -138,8 +138,8 @@ locals {
       valueFrom = data.aws_secretsmanager_secret.notify_api_key.arn
     },
     {
-      name      = "OS_PLACES_API_KEY"
-      valueFrom = data.aws_secretsmanager_secret.os_places_api_key.arn
+      name      = "OS_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.os_api_key.arn
     },
     {
       name      = "EPC_REGISTER_CLIENT_SECRET"


### PR DESCRIPTION
## Ticket number

PRSD-1021

## Goal of change

Renames OS API key to be more general

## Description of main change(s)

As above

## Anything you'd like to highlight to the reviewer?

- This ticket prompted the renaming as we'll be using another OS API (with the same key)
- After merging, populate the new tf-integration-os-api-key secret. Go to AWS Console -> Secrets Manager -> tf-integration-os-api-key and set the value (the value can be found in the development .env file in Keeper)

## Checklist
Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Any special release instructions (e.g. set environment variables) have been added as checklist items to a draft PR (merging `main` into `test`) for the next release.