### PR TITLE
PDJB-727: Remove Google Analytics SSM parameters and ECS environment variables

### DIFF
--- a/terraform/environment_template/ecs_task_definition/data.tf.template
+++ b/terraform/environment_template/ecs_task_definition/data.tf.template
@@ -112,7 +112,6 @@ data "aws_ssm_parameter" "plausible_analytics_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
 }
 
-
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/environment_template/ecs_task_definition/data.tf.template
+++ b/terraform/environment_template/ecs_task_definition/data.tf.template
@@ -112,13 +112,6 @@ data "aws_ssm_parameter" "plausible_analytics_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
 }
 
-data "aws_ssm_parameter" "google_analytics_measurement_id" {
-  name = "${local.environment_name}-prsdb-google-analytics-measurement-id"
-}
-
-data "aws_ssm_parameter" "google_analytics_cookie_domain" {
-  name = "${local.environment_name}-prsdb-google-analytics-cookie-domain"
-}
 
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -114,14 +114,7 @@ locals {
       name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
       value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
     },
-    {
-      name  = "GOOGLE_ANALYTICS_MEASUREMENT_ID"
-      value = data.aws_ssm_parameter.google_analytics_measurement_id.value
-    },
-    {
-      name  = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
-      value = data.aws_ssm_parameter.google_analytics_cookie_domain.value
-    },
+
     {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}"

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -114,7 +114,6 @@ locals {
       name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
       value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
     },
-
     {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}"

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -112,7 +112,6 @@ data "aws_ssm_parameter" "plausible_analytics_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
 }
 
-
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -112,13 +112,6 @@ data "aws_ssm_parameter" "plausible_analytics_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
 }
 
-data "aws_ssm_parameter" "google_analytics_measurement_id" {
-  name = "${local.environment_name}-prsdb-google-analytics-measurement-id"
-}
-
-data "aws_ssm_parameter" "google_analytics_cookie_domain" {
-  name = "${local.environment_name}-prsdb-google-analytics-cookie-domain"
-}
 
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -114,14 +114,7 @@ locals {
       name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
       value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
     },
-    {
-      name  = "GOOGLE_ANALYTICS_MEASUREMENT_ID"
-      value = data.aws_ssm_parameter.google_analytics_measurement_id.value
-    },
-    {
-      name  = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
-      value = data.aws_ssm_parameter.google_analytics_cookie_domain.value
-    },
+
     {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}"

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -114,7 +114,6 @@ locals {
       name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
       value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
     },
-
     {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}"

--- a/terraform/modules/ssm/parameters.tf
+++ b/terraform/modules/ssm/parameters.tf
@@ -122,25 +122,6 @@ resource "aws_ssm_parameter" "plausible_analytics_domain_id" {
   }
 }
 
-resource "aws_ssm_parameter" "google_analytics_measurement_id" {
-  name  = "${var.environment_name}-prsdb-google-analytics-measurement-id"
-  type  = "String"
-  value = "default_to_be_set_manually" # To be set manually on AWS
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-}
-
-resource "aws_ssm_parameter" "google_analytics_cookie_domain" {
-  name  = "${var.environment_name}-prsdb-google-analytics-cookie-domain"
-  type  = "String"
-  value = "default_to_be_set_manually" # To be set manually on AWS
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-}
 
 resource "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name  = "${var.environment_name}-prsdb-beta-feedback-team-email-address"

--- a/terraform/modules/ssm/parameters.tf
+++ b/terraform/modules/ssm/parameters.tf
@@ -122,7 +122,6 @@ resource "aws_ssm_parameter" "plausible_analytics_domain_id" {
   }
 }
 
-
 resource "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name  = "${var.environment_name}-prsdb-beta-feedback-team-email-address"
   type  = "String"

--- a/terraform/nft/ecs_task_definition/data.tf
+++ b/terraform/nft/ecs_task_definition/data.tf
@@ -112,7 +112,6 @@ data "aws_ssm_parameter" "plausible_analytics_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
 }
 
-
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/nft/ecs_task_definition/data.tf
+++ b/terraform/nft/ecs_task_definition/data.tf
@@ -112,13 +112,6 @@ data "aws_ssm_parameter" "plausible_analytics_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
 }
 
-data "aws_ssm_parameter" "google_analytics_measurement_id" {
-  name = "${local.environment_name}-prsdb-google-analytics-measurement-id"
-}
-
-data "aws_ssm_parameter" "google_analytics_cookie_domain" {
-  name = "${local.environment_name}-prsdb-google-analytics-cookie-domain"
-}
 
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -114,14 +114,7 @@ locals {
       name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
       value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
     },
-    {
-      name  = "GOOGLE_ANALYTICS_MEASUREMENT_ID"
-      value = data.aws_ssm_parameter.google_analytics_measurement_id.value
-    },
-    {
-      name  = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
-      value = data.aws_ssm_parameter.google_analytics_cookie_domain.value
-    },
+
     {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}"

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -114,7 +114,6 @@ locals {
       name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
       value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
     },
-
     {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}"

--- a/terraform/production/ecs_task_definition/data.tf
+++ b/terraform/production/ecs_task_definition/data.tf
@@ -112,7 +112,6 @@ data "aws_ssm_parameter" "plausible_analytics_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
 }
 
-
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/production/ecs_task_definition/data.tf
+++ b/terraform/production/ecs_task_definition/data.tf
@@ -112,13 +112,6 @@ data "aws_ssm_parameter" "plausible_analytics_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
 }
 
-data "aws_ssm_parameter" "google_analytics_measurement_id" {
-  name = "${local.environment_name}-prsdb-google-analytics-measurement-id"
-}
-
-data "aws_ssm_parameter" "google_analytics_cookie_domain" {
-  name = "${local.environment_name}-prsdb-google-analytics-cookie-domain"
-}
 
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -114,14 +114,7 @@ locals {
       name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
       value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
     },
-    {
-      name  = "GOOGLE_ANALYTICS_MEASUREMENT_ID"
-      value = data.aws_ssm_parameter.google_analytics_measurement_id.value
-    },
-    {
-      name  = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
-      value = data.aws_ssm_parameter.google_analytics_cookie_domain.value
-    },
+
     {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}"

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -114,7 +114,6 @@ locals {
       name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
       value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
     },
-
     {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}"

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -112,7 +112,6 @@ data "aws_ssm_parameter" "plausible_analytics_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
 }
 
-
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -112,13 +112,6 @@ data "aws_ssm_parameter" "plausible_analytics_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
 }
 
-data "aws_ssm_parameter" "google_analytics_measurement_id" {
-  name = "${local.environment_name}-prsdb-google-analytics-measurement-id"
-}
-
-data "aws_ssm_parameter" "google_analytics_cookie_domain" {
-  name = "${local.environment_name}-prsdb-google-analytics-cookie-domain"
-}
 
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -114,14 +114,7 @@ locals {
       name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
       value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
     },
-    {
-      name  = "GOOGLE_ANALYTICS_MEASUREMENT_ID"
-      value = data.aws_ssm_parameter.google_analytics_measurement_id.value
-    },
-    {
-      name  = "GOOGLE_ANALYTICS_COOKIE_DOMAIN"
-      value = data.aws_ssm_parameter.google_analytics_cookie_domain.value
-    },
+
     {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}"

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -114,7 +114,6 @@ locals {
       name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
       value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
     },
-
     {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}"


### PR DESCRIPTION
## Ticket number

PDJB-727

## Goal of change

Remove Google Analytics infrastructure config (SSM parameters and ECS environment variables) now that GA has been removed from the webapp.

## Description of main change(s)

- Removes the \google_analytics_measurement_id\ and \google_analytics_cookie_domain\ SSM parameter resource definitions from the SSM module
- Removes the corresponding SSM data source lookups from the ECS task definition in all environments (environment_template, integration, production, test, nft)
- Removes the \GOOGLE_ANALYTICS_MEASUREMENT_ID\ and \GOOGLE_ANALYTICS_COOKIE_DOMAIN\ ECS container environment variables from all environments

Companion change to communitiesuk/prsdb-webapp#1168.

## Anything you'd like to highlight to the reviewer?

This is a straightforward removal of all Google Analytics references from the infra repo. Plausible Analytics references are left untouched.
