### PR TITLE
PDJB-NONE: Removes redundent eventbridge triggers for scheduled tasks

### DIFF
--- a/terraform/modules/scheduled_tasks/iam.tf
+++ b/terraform/modules/scheduled_tasks/iam.tf
@@ -16,24 +16,6 @@ resource "aws_iam_role" "scheduled_tasks" {
           StringEquals = {
             "aws:SourceAccount" = data.aws_caller_identity.current.account_id
           }
-          ArnLike = {
-            "aws:SourceArn" = "arn:aws:scheduler:*:${data.aws_caller_identity.current.account_id}:schedule/${aws_scheduler_schedule_group.scheduled_tasks.name}/*"
-          }
-        }
-      },
-      {
-        Effect = "Allow"
-        Principal = {
-          Service = "events.amazonaws.com"
-        }
-        Action = "sts:AssumeRole"
-        Condition = {
-          StringEquals = {
-            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
-          }
-          ArnLike = {
-            "aws:SourceArn" = "arn:aws:events:*:${data.aws_caller_identity.current.account_id}:rule/${var.environment_name}-*-scheduled-task"
-          }
         }
       }
     ]

--- a/terraform/modules/scheduled_tasks/scheduler.tf
+++ b/terraform/modules/scheduled_tasks/scheduler.tf
@@ -1,12 +1,3 @@
-resource "aws_cloudwatch_event_rule" "scheduled_tasks" {
-  for_each = local.tasks
-
-  name                = "${var.environment_name}-${each.key}-scheduled-task"
-  description         = "Trigger ${each.key} scheduled task in ${var.environment_name}"
-  schedule_expression = each.value.schedule_expression
-  state               = "ENABLED"
-}
-
 resource "aws_scheduler_schedule_group" "scheduled_tasks" {
   name = "${var.environment_name}-scheduled-tasks-group"
 }
@@ -63,27 +54,5 @@ resource "aws_scheduler_schedule" "scheduled_tasks" {
     }
   }
 
-}
-
-resource "aws_cloudwatch_event_target" "scheduled_tasks" {
-  for_each = local.tasks
-
-  rule      = aws_cloudwatch_event_rule.scheduled_tasks[each.key].name
-  target_id = "${var.environment_name}-${each.key}-task"
-  arn       = aws_ecs_cluster.scheduled_tasks.arn
-  role_arn  = aws_iam_role.scheduled_tasks.arn
-
-  ecs_target {
-    task_count          = 1
-    task_definition_arn = each.value.task_family_arn
-    launch_type         = "FARGATE"
-    platform_version    = "LATEST"
-
-    network_configuration {
-      subnets          = var.private_subnet_ids
-      security_groups  = var.security_group_ids
-      assign_public_ip = false
-    }
-  }
 }
 


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Fix scheduled task infra

## Description of main change(s)

- Removing IAM condition that was preventing the scheduler from being created/ triggered
- Removing the redundant event bridge target which was confusing matters by triggering the tasks incorrectly

## Anything you'd like to highlight to the reviewer?

There were compounding issues that was preventing scheduled tasks from being triggered correctly:
- We had left over event bridge targets from our switch to schedulers which did not have permission to run the tasks
- During a Wiz scan it picked up this permissions issue, but also requested we add a new condition to the IAM permissions for the scheduler principal
- Both of these changes were made at once, which had the effect of 1) blocking the scheduler, and 2) allowing the previously dormant event bridge target to trigger the events
- This has led to confusing behaviour with the tasks including conflicting error messages (task failed to be triggered, but yet there are also logs from those tasks saying that they failed during start up)
- This change should leave us with just the scheduler, hopefully with the correct permissions