### PR TITLE
PDJB-NONE: Re-enables IP restrictions being overridden in the pipeline

### DIFF
--- a/.github/workflows/apply-production.yml
+++ b/.github/workflows/apply-production.yml
@@ -14,5 +14,5 @@ jobs:
       environment: production
       aws-account-id: 879161327637
       maintenance-mode-on: ${{ vars.MAINTENANCE_MODE_ON_PRODUCTION == 'true' }}
-      ip-restrictions-on: ${{ vars.IP_RESTRICTIONS == 'true' }}
+      ip-restrictions-on: ${{ vars.IP_RESTRICTIONS_ON == 'true' }}
     secrets: inherit

--- a/.github/workflows/apply-production.yml
+++ b/.github/workflows/apply-production.yml
@@ -14,4 +14,5 @@ jobs:
       environment: production
       aws-account-id: 879161327637
       maintenance-mode-on: ${{ vars.MAINTENANCE_MODE_ON_PRODUCTION == 'true' }}
+      ip-restrictions-on: ${{ vars.IP_RESTRICTIONS == 'true' }}
     secrets: inherit

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -11,6 +11,10 @@ on:
       maintenance-mode-on:
         required: true
         type: boolean
+      ip-restrictions-on:
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   id-token: write
@@ -20,6 +24,7 @@ env:
   AWS_REGION: "eu-west-2"
   TF_VAR_alarm_email_address: ${{ secrets.ALARMS_EMAIL }}
   TF_VAR_maintenance_mode_on: ${{ inputs.maintenance-mode-on }}
+  TF_VAR_ip_restrictions_on: ${{ inputs.ip-restrictions-on }}
 
 jobs:
   validate-target-environment:


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Ensure that the IP_RESTRICTIONS_ON environement variable is respected when present

## Description of main change(s)

We have an environment variable set on the production environment on github that specifies when IP restrictions should be on. This was being ignored following a refactor of the pipelines. This reinstates it.