### PR TITLE
PDJB-681: Add require-passcode profile to webapp

### DIFF
--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -116,7 +116,7 @@ locals {
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"
-      value = "default, ${local.environment_name}"
+      value = "default, ${local.environment_name}, require-passcode"
     },
     {
       name  = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -116,7 +116,7 @@ locals {
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"
-      value = "default, ${local.environment_name}"
+      value = "default, ${local.environment_name}, require-passcode"
     },
     {
       name  = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -116,7 +116,7 @@ locals {
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"
-      value = "default, ${local.environment_name}"
+      value = "default, ${local.environment_name}, require-passcode"
     },
     {
       name  = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -116,7 +116,7 @@ locals {
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"
-      value = "default, ${local.environment_name}"
+      value = "default, ${local.environment_name}, require-passcode"
     },
     {
       name  = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"


### PR DESCRIPTION
## Ticket number

PDJB-681

## Goal of change

Enable passcodes in all environments apart from nft by activating the require-passcode Spring profile for the webapp.

## Description of main change(s)

Adds the require-passcode profile to the SPRING_PROFILES_ACTIVE environment variable for the webapp container in all non-nft environments (test, integration, production) and the environment template.