### PR TITLE
PDJB-NONE: Rename Plausible env var to PLAUSIBLE_SITE_ID

### DIFF
--- a/terraform/environment_template/ecs_task_definition/data.tf.template
+++ b/terraform/environment_template/ecs_task_definition/data.tf.template
@@ -108,8 +108,8 @@ data "aws_ssm_parameter" "local_council_base_url" {
   name = "${local.environment_name}-prsdb-local-council-base-url"
 }
 
-data "aws_ssm_parameter" "plausible_analytics_domain_id" {
-  name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
+data "aws_ssm_parameter" "plausible_site_id" {
+  name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -111,8 +111,8 @@ locals {
       value = data.aws_ssm_parameter.epc_certificate_base_url.value
     },
     {
-      name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
-      value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
+      name  = "PLAUSIBLE_SITE_ID"
+      value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -108,8 +108,8 @@ data "aws_ssm_parameter" "local_council_base_url" {
   name = "${local.environment_name}-prsdb-local-council-base-url"
 }
 
-data "aws_ssm_parameter" "plausible_analytics_domain_id" {
-  name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
+data "aws_ssm_parameter" "plausible_site_id" {
+  name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -111,8 +111,8 @@ locals {
       value = data.aws_ssm_parameter.epc_certificate_base_url.value
     },
     {
-      name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
-      value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
+      name  = "PLAUSIBLE_SITE_ID"
+      value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"

--- a/terraform/modules/ssm/parameters.tf
+++ b/terraform/modules/ssm/parameters.tf
@@ -112,8 +112,8 @@ resource "aws_ssm_parameter" "local_council_base_url" {
   value = var.local_council_base_url
 }
 
-resource "aws_ssm_parameter" "plausible_analytics_domain_id" {
-  name  = "${var.environment_name}-prsdb-plausible-analytics-domain-id"
+resource "aws_ssm_parameter" "plausible_site_id" {
+  name  = "${var.environment_name}-prsdb-plausible-site-id"
   type  = "String"
   value = "default_to_be_set_manually" # To be set manually on AWS
 

--- a/terraform/nft/ecs_task_definition/data.tf
+++ b/terraform/nft/ecs_task_definition/data.tf
@@ -108,8 +108,8 @@ data "aws_ssm_parameter" "local_council_base_url" {
   name = "${local.environment_name}-prsdb-local-council-base-url"
 }
 
-data "aws_ssm_parameter" "plausible_analytics_domain_id" {
-  name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
+data "aws_ssm_parameter" "plausible_site_id" {
+  name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -111,8 +111,8 @@ locals {
       value = data.aws_ssm_parameter.epc_certificate_base_url.value
     },
     {
-      name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
-      value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
+      name  = "PLAUSIBLE_SITE_ID"
+      value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"

--- a/terraform/production/ecs_task_definition/data.tf
+++ b/terraform/production/ecs_task_definition/data.tf
@@ -108,8 +108,8 @@ data "aws_ssm_parameter" "local_council_base_url" {
   name = "${local.environment_name}-prsdb-local-council-base-url"
 }
 
-data "aws_ssm_parameter" "plausible_analytics_domain_id" {
-  name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
+data "aws_ssm_parameter" "plausible_site_id" {
+  name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -111,8 +111,8 @@ locals {
       value = data.aws_ssm_parameter.epc_certificate_base_url.value
     },
     {
-      name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
-      value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
+      name  = "PLAUSIBLE_SITE_ID"
+      value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -108,8 +108,8 @@ data "aws_ssm_parameter" "local_council_base_url" {
   name = "${local.environment_name}-prsdb-local-council-base-url"
 }
 
-data "aws_ssm_parameter" "plausible_analytics_domain_id" {
-  name = "${local.environment_name}-prsdb-plausible-analytics-domain-id"
+data "aws_ssm_parameter" "plausible_site_id" {
+  name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -111,8 +111,8 @@ locals {
       value = data.aws_ssm_parameter.epc_certificate_base_url.value
     },
     {
-      name  = "PLAUSIBLE_ANALYTICS_DOMAIN_ID"
-      value = data.aws_ssm_parameter.plausible_analytics_domain_id.value
+      name  = "PLAUSIBLE_SITE_ID"
+      value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Rename the Plausible analytics env var to align with the webapp move from the legacy v1 Plausible script to the v2 site-specific script (see communitiesuk/prsdb-webapp#1246).

## Description of main change(s)

- Renames the SSM parameter `<env>-prsdb-plausible-analytics-domain-id` to `<env>-prsdb-plausible-site-id`.
- Renames the ECS task env var `PLAUSIBLE_ANALYTICS_DOMAIN_ID` to `PLAUSIBLE_SITE_ID` across the environment template and the integration, test, nft, and production task definitions.
- Renames the corresponding terraform `data` / `resource` blocks to `plausible_site_id`.

## Anything you''d like to highlight to the reviewer?

- The SSM parameter value is still managed manually in AWS (the resource has `ignore_changes = [value]`). After this is applied, the new `<env>-prsdb-plausible-site-id` SSM parameter will be created with the placeholder value and will need its real per-environment Plausible v2 site ID set manually for each environment before the webapp release goes out. The old `<env>-prsdb-plausible-analytics-domain-id` parameter will be removed by terraform and can be cleaned up if anything still references it.
- The matching webapp change is in communitiesuk/prsdb-webapp#1246.

## Checklist

- [x] Any special release instructions (e.g. set environment variables) have been added as checklist items to a draft PR (merging `main` into `test`) for the next release.

  The new `<env>-prsdb-plausible-site-id` SSM parameter must have its value set manually in AWS Parameter Store for each environment (integration, test, nft, production) using the v2 site IDs from the Plausible dashboard before the webapp release that depends on this change.
