### PR TITLE
Update maintenance page contact email

### DIFF
--- a/terraform/modules/frontdoor/maintenance_page/index.html
+++ b/terraform/modules/frontdoor/maintenance_page/index.html
@@ -70,7 +70,7 @@
                 <h2 class="govuk-visually-hidden">Support links</h2>
                 <div class="govuk-footer__meta-custom">
                     <span>If you need help using this private beta, get in touch by email:</span>
-                    <a class="govuk-footer__link" href="mailto: PRSDatabase@communities.gov.uk">PRSDatabase@communities.gov.uk</a>
+                    <a class="govuk-footer__link" href="mailto: prs.beta@communities.gov.uk">prs.beta@communities.gov.uk</a>
                     <span>.</span>
                     <br>
                     <span>Or by phone: 03034447000</span>


### PR DESCRIPTION
## Ticket number

PDJB-616

## Goal of change

Update the placeholder contact email on the maintenance page to the correct address.

## Description of main change(s)

- Updates the contact email shown on the maintenance page from `PRSDatabase@communities.gov.uk` to `prs.beta@communities.gov.uk`.
