### PR TITLE
PDJB-NONE: Track maintenance page asset content with etag

### DIFF
--- a/terraform/modules/frontdoor/maintenance_page.tf
+++ b/terraform/modules/frontdoor/maintenance_page.tf
@@ -11,6 +11,7 @@ resource "aws_s3_object" "maintenance_page_index_file" {
   bucket        = module.maintenance_page_bucket.bucket
   key           = "maintenance"
   source        = "../modules/frontdoor/maintenance_page/index.html"
+  etag          = filemd5("../modules/frontdoor/maintenance_page/index.html")
   content_type  = "text/html"
   cache_control = "no-cache"
 }
@@ -19,6 +20,7 @@ resource "aws_s3_object" "maintenance_page_style_file" {
   bucket       = module.maintenance_page_bucket.bucket
   key          = "govuk-frontend-5.11.2.min.css"
   source       = "../modules/frontdoor/maintenance_page/govuk-frontend-5.11.2.min.css"
+  etag         = filemd5("../modules/frontdoor/maintenance_page/govuk-frontend-5.11.2.min.css")
   content_type = "text/css"
 }
 
@@ -26,6 +28,7 @@ resource "aws_s3_object" "govuk_crest_svg" {
   bucket       = module.maintenance_page_bucket.bucket
   key          = "/assets/images/govuk-crest.svg"
   source       = "../modules/frontdoor/maintenance_page/assets/images/govuk-crest.svg"
+  etag         = filemd5("../modules/frontdoor/maintenance_page/assets/images/govuk-crest.svg")
   content_type = "image/svg+xml"
 }
 
@@ -33,6 +36,7 @@ resource "aws_s3_object" "gds_font_bold" {
   bucket       = module.maintenance_page_bucket.bucket
   key          = "/assets/fonts/bold-b542beb274-v2.woff2"
   source       = "../modules/frontdoor/maintenance_page/assets/fonts/bold-b542beb274-v2.woff2"
+  etag         = filemd5("../modules/frontdoor/maintenance_page/assets/fonts/bold-b542beb274-v2.woff2")
   content_type = "font/woff2"
 }
 
@@ -40,6 +44,7 @@ resource "aws_s3_object" "gds_font_light" {
   bucket       = module.maintenance_page_bucket.bucket
   key          = "/assets/fonts/light-94a07e06a1-v2.woff2"
   source       = "../modules/frontdoor/maintenance_page/assets/fonts/light-94a07e06a1-v2.woff2"
+  etag         = filemd5("../modules/frontdoor/maintenance_page/assets/fonts/light-94a07e06a1-v2.woff2")
   content_type = "font/woff2"
 }
 


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Ensure edits to the maintenance page assets actually get re-uploaded to S3 by the next Terraform apply.

## Description of main change(s)

- Adds `etag = filemd5(...)` to each `aws_s3_object` resource in `terraform/modules/frontdoor/maintenance_page.tf` (the HTML, the GOV.UK Frontend CSS, the crest SVG, and both font files).
- This means Terraform now tracks the content of each asset as part of the resource''s state, so any future change to the file on disk produces a plan diff and a re-upload. Previously Terraform only tracked the `source` path string, so content-only edits were silently no-op''d.

The trigger for this fix was PR #257, which updated the contact email on the maintenance page. The apply ran green on integration but the new email never reached the S3 object — once this PR is merged and applied, the new etag values will cause all five assets to be re-uploaded, picking up the email change (and any other content-only changes since the assets were first created).

## Anything you''d like to highlight to the reviewer?

- Used `etag` rather than `source_hash` because the maintenance page bucket is SSE-S3 (AES256, not KMS) and all five assets are well below the 5MB multipart threshold, so etag will match S3''s value cleanly. If we ever switch this bucket to KMS or upload a file larger than 5MB, swap `etag` for `source_hash`.
- The first apply after merge will show 5 in-place updates to `aws_s3_object` resources — that is expected and is the mechanism that actually pushes the previously-missed email change live.

