### PR TITLE
PDJB-NONE: Resolve production IP_RESTRICTIONS_ON variable in environment scope

### DIFF
--- a/.github/workflows/apply-production.yml
+++ b/.github/workflows/apply-production.yml
@@ -6,13 +6,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  resolve-environment-variables:
+    name: Resolve environment variables
+    runs-on: ubuntu-latest
+    environment: production
+    outputs:
+      ip-restrictions-on: ${{ vars.IP_RESTRICTIONS_ON == 'true' }}
+    steps:
+      - run: echo "Resolved environment variables"
+
   apply:
     if: github.ref == 'refs/heads/production'
     name: Apply
+    needs: resolve-environment-variables
     uses: ./.github/workflows/apply.yml
     with:
       environment: production
       aws-account-id: 879161327637
       maintenance-mode-on: ${{ vars.MAINTENANCE_MODE_ON_PRODUCTION == 'true' }}
-      ip-restrictions-on: ${{ vars.IP_RESTRICTIONS_ON == 'true' }}
+      ip-restrictions-on: ${{ needs.resolve-environment-variables.outputs.ip-restrictions-on == 'true' }}
     secrets: inherit


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Ensure the `IP_RESTRICTIONS_ON` variable defined on the `production` GitHub Actions environment is actually read when deploying to production.

## Description of main change(s)

- Adds a small `resolve-environment-variables` job to `apply-production.yml` that runs with `environment: production` and exposes `vars.IP_RESTRICTIONS_ON` as a job output.
- The `apply` reusable-workflow call now reads `ip-restrictions-on` from that output instead of evaluating `vars.IP_RESTRICTIONS_ON` directly.

The previous setup evaluated `vars.IP_RESTRICTIONS_ON` on the caller job, which has no `environment:` declared (and cannot have one — jobs that `uses:` a reusable workflow are not allowed to set `environment:`). Environment-scoped variables only resolve on jobs that declare the matching environment, so the expression always produced an empty string, `'''' == ''true''` was `false`, and `false` was passed in regardless of what the variable was set to in the production environment.
