### PR TITLE
PDJB-NONE: Increase Paketo class count budget to raise Metaspace cap

### DIFF
--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -126,6 +126,10 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "BPL_JVM_LOADED_CLASS_COUNT"
+      value = "40000"
+    },
   ]
   # We set default Spring profiles for scheduled tasks to allow the application to correctly handle the case where a scheduled task is created without a dedicated profile. These should always be overridden by task-specific profiles.
   scheduled_tasks_only_environment_variables = [

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -126,6 +126,10 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "BPL_JVM_LOADED_CLASS_COUNT"
+      value = "40000"
+    },
   ]
   # We set default Spring profiles for scheduled tasks to allow the application to correctly handle the case where a scheduled task is created without a dedicated profile. These should always be overridden by task-specific profiles.
   scheduled_tasks_only_environment_variables = [

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -126,6 +126,10 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "BPL_JVM_LOADED_CLASS_COUNT"
+      value = "40000"
+    },
   ]
   # We set default Spring profiles for scheduled tasks to allow the application to correctly handle the case where a scheduled task is created without a dedicated profile. These should always be overridden by task-specific profiles.
   scheduled_tasks_only_environment_variables = [

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -126,6 +126,10 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "BPL_JVM_LOADED_CLASS_COUNT"
+      value = "40000"
+    },
   ]
   # We set default Spring profiles for scheduled tasks to allow the application to correctly handle the case where a scheduled task is created without a dedicated profile. These should always be overridden by task-specific profiles.
   scheduled_tasks_only_environment_variables = [


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Stop the integration webapp container being killed by repeated `OutOfMemoryError: Metaspace` events.

## Description of main change(s)

- Adds `BPL_JVM_LOADED_CLASS_COUNT=40000` to the webapp task environment in all four environments (integration, test, nft, production)

## Anything you''d like to highlight to the reviewer?

CloudWatch metrics (now flowing courtesy of webapp PR #1297) confirmed Metaspace usage was peaking at the 182 MB cap and that the recent container terminations correspond to those peaks (used drops to ~7 MB then climbs back, i.e. fresh JVM after `+ExitOnOutOfMemoryError`).

The Paketo memory calculator sizes Metaspace from `BPL_JVM_LOADED_CLASS_COUNT` (default ~28891 inferred from the JAR). The app actually loads enough classes at steady state to brush against the resulting cap; bumping the estimate to 40000 grows Metaspace by roughly 70 MB at the cost of a similar reduction in heap. Heap has been under-utilised in practice, so this should be a net win.