### PR TITLE
PDJB-NONE: Bump webapp Fargate task memory to 2 GiB

### DIFF
--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -177,7 +177,7 @@ module "webapp_ecs_task_definition" {
   ecs_task_role_arn           = data.aws_iam_role.webapp_ecs_task.arn
   # TODO: consider what our requirements are for the instance
   task_cpu              = 512
-  task_memory           = 1024
+  task_memory           = 2048
   task_name             = "prsdb-webapp"
   environment_variables = concat(local.common_environment_variables, local.webapp_only_environment_variables)
   secrets               = concat(local.common_secrets, local.webapp_secrets)

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -181,7 +181,7 @@ module "webapp_ecs_task_definition" {
   ecs_task_role_arn           = data.aws_iam_role.webapp_ecs_task.arn
   # TODO: consider what our requirements are for the instance
   task_cpu              = 512
-  task_memory           = 1024
+  task_memory           = 2048
   task_name             = "prsdb-webapp"
   environment_variables = concat(local.common_environment_variables, local.webapp_only_environment_variables)
   secrets               = concat(local.common_secrets, local.webapp_secrets)

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -181,7 +181,7 @@ module "webapp_ecs_task_definition" {
   ecs_task_role_arn           = data.aws_iam_role.webapp_ecs_task.arn
   # TODO: consider what our requirements are for the instance
   task_cpu              = 512
-  task_memory           = 1024
+  task_memory           = 2048
   task_name             = "prsdb-webapp"
   environment_variables = concat(local.common_environment_variables, local.webapp_only_environment_variables)
   secrets               = concat(local.common_secrets, local.webapp_secrets)

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -181,7 +181,7 @@ module "webapp_ecs_task_definition" {
   ecs_task_role_arn           = data.aws_iam_role.webapp_ecs_task.arn
   # TODO: consider what our requirements are for the instance
   task_cpu              = 512
-  task_memory           = 1024
+  task_memory           = 2048
   task_name             = "prsdb-webapp"
   environment_variables = concat(local.common_environment_variables, local.webapp_only_environment_variables)
   secrets               = concat(local.common_secrets, local.webapp_secrets)


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Provide adequate memory headroom for the prsdb-webapp Fargate task so the container does not run at 98% steady-state utilisation under normal load.

## Description of main change(s)

- Bumps `task_memory` from 1024 MiB to 2048 MiB for the webapp task in integration, test and nft environments
- Updates the environment template to match
- Production already runs at 4096 MiB so is unchanged
- Scheduled-task tasks unchanged (different workload, already 4096 MiB in production)

## Anything you'd like to highlight to the reviewer?

CloudWatch metrics (now flowing after #1297) showed the webapp's true post-warm-up working set is around 837 MB of JVM committed memory plus ~150 MB of native overhead, which leaves no headroom in a 1024 MiB container. SerialGC (auto-selected because the task has 1 vCPU and a small heap) does not return committed pages to the OS, so each burst of activity ratchets memory up permanently until the container plateaus near its limit.

Cost impact is approximately £15-20/month across the three lower environments combined. Previous knob (#266 - bumping `BPL_JVM_LOADED_CLASS_COUNT`) addressed the Metaspace OOM but actually grew committed memory by widening the calculator's Metaspace allocation. This PR addresses the resulting tightness against the container limit.

## Checklist

- [ ] No special release instructions