### PR TITLE
Release main to nft #8

### DIFF
--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -177,7 +177,7 @@ module "webapp_ecs_task_definition" {
   ecs_task_role_arn           = data.aws_iam_role.webapp_ecs_task.arn
   # TODO: consider what our requirements are for the instance
   task_cpu              = 512
-  task_memory           = 1024
+  task_memory           = 2048
   task_name             = "prsdb-webapp"
   environment_variables = concat(local.common_environment_variables, local.webapp_only_environment_variables)
   secrets               = concat(local.common_secrets, local.webapp_secrets)

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -122,6 +122,10 @@ locals {
       name  = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"
       value = data.aws_ssm_parameter.beta_feedback_team_email_address.value
     },
+    {
+      name  = "METRICS_CLOUDWATCH_NAMESPACE"
+      value = "prsdb-webapp/${local.environment_name}"
+    },
   ]
   # We set default Spring profiles for scheduled tasks to allow the application to correctly handle the case where a scheduled task is created without a dedicated profile. These should always be overridden by task-specific profiles.
   scheduled_tasks_only_environment_variables = [

--- a/terraform/environment_template/main.tf.template
+++ b/terraform/environment_template/main.tf.template
@@ -232,6 +232,7 @@ module "monitoring" {
   database_allocated_storage     = local.database_allocated_storage
   database_identifier            = module.database.database_identifier
   waf_acl_name                   = module.frontdoor.waf_acl_name
+  webapp_ecs_task_role_name      = module.ecr.webapp_ecs_task_role_name
 }
 
 module "scheduled_tasks" {

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -181,7 +181,7 @@ module "webapp_ecs_task_definition" {
   ecs_task_role_arn           = data.aws_iam_role.webapp_ecs_task.arn
   # TODO: consider what our requirements are for the instance
   task_cpu              = 512
-  task_memory           = 1024
+  task_memory           = 2048
   task_name             = "prsdb-webapp"
   environment_variables = concat(local.common_environment_variables, local.webapp_only_environment_variables)
   secrets               = concat(local.common_secrets, local.webapp_secrets)

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -122,6 +122,10 @@ locals {
       name  = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"
       value = data.aws_ssm_parameter.beta_feedback_team_email_address.value
     },
+    {
+      name  = "METRICS_CLOUDWATCH_NAMESPACE"
+      value = "prsdb-webapp/${local.environment_name}"
+    },
   ]
   # We set default Spring profiles for scheduled tasks to allow the application to correctly handle the case where a scheduled task is created without a dedicated profile. These should always be overridden by task-specific profiles.
   scheduled_tasks_only_environment_variables = [

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -126,6 +126,10 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "BPL_JVM_LOADED_CLASS_COUNT"
+      value = "40000"
+    },
   ]
   # We set default Spring profiles for scheduled tasks to allow the application to correctly handle the case where a scheduled task is created without a dedicated profile. These should always be overridden by task-specific profiles.
   scheduled_tasks_only_environment_variables = [

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -251,6 +251,7 @@ module "monitoring" {
   database_allocated_storage     = local.database_allocated_storage
   database_identifier            = module.database.database_identifier
   waf_acl_name                   = module.frontdoor.waf_acl_name
+  webapp_ecs_task_role_name      = module.ecr.webapp_ecs_task_role_name
 }
 
 module "scheduled_tasks" {

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -61,3 +61,8 @@ variable "waf_acl_name" {
   description = "Name of WAF web ACL to create alarms for"
   type        = string
 }
+
+variable "webapp_ecs_task_role_name" {
+  description = "Name of the webapp ECS task role to grant CloudWatch metric publishing permissions to"
+  type        = string
+}

--- a/terraform/modules/monitoring/webapp_metrics_publishing.tf
+++ b/terraform/modules/monitoring/webapp_metrics_publishing.tf
@@ -1,0 +1,22 @@
+# Allows the webapp ECS task role to publish JVM/process metrics to CloudWatch
+# via Micrometer's CloudWatch registry.
+# cloudwatch:PutMetricData does not support resource-level permissions, so a wildcard is required.
+# See https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatch.html
+# tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "webapp_publish_cloudwatch_metrics" {
+  statement {
+    actions   = ["cloudwatch:PutMetricData"]
+    resources = ["*"]
+    effect    = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "webapp_publish_cloudwatch_metrics" {
+  name   = "${var.environment_name}-webapp-publish-cloudwatch-metrics"
+  policy = data.aws_iam_policy_document.webapp_publish_cloudwatch_metrics.json
+}
+
+resource "aws_iam_role_policy_attachment" "webapp_publish_cloudwatch_metrics" {
+  role       = var.webapp_ecs_task_role_name
+  policy_arn = aws_iam_policy.webapp_publish_cloudwatch_metrics.arn
+}

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -181,7 +181,7 @@ module "webapp_ecs_task_definition" {
   ecs_task_role_arn           = data.aws_iam_role.webapp_ecs_task.arn
   # TODO: consider what our requirements are for the instance
   task_cpu              = 512
-  task_memory           = 1024
+  task_memory           = 2048
   task_name             = "prsdb-webapp"
   environment_variables = concat(local.common_environment_variables, local.webapp_only_environment_variables)
   secrets               = concat(local.common_secrets, local.webapp_secrets)

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -122,6 +122,10 @@ locals {
       name  = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"
       value = data.aws_ssm_parameter.beta_feedback_team_email_address.value
     },
+    {
+      name  = "METRICS_CLOUDWATCH_NAMESPACE"
+      value = "prsdb-webapp/${local.environment_name}"
+    },
   ]
   # We set default Spring profiles for scheduled tasks to allow the application to correctly handle the case where a scheduled task is created without a dedicated profile. These should always be overridden by task-specific profiles.
   scheduled_tasks_only_environment_variables = [

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -126,6 +126,10 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "BPL_JVM_LOADED_CLASS_COUNT"
+      value = "40000"
+    },
   ]
   # We set default Spring profiles for scheduled tasks to allow the application to correctly handle the case where a scheduled task is created without a dedicated profile. These should always be overridden by task-specific profiles.
   scheduled_tasks_only_environment_variables = [

--- a/terraform/nft/main.tf
+++ b/terraform/nft/main.tf
@@ -255,6 +255,7 @@ module "monitoring" {
   database_allocated_storage     = local.database_allocated_storage
   database_identifier            = module.database.database_identifier
   waf_acl_name                   = module.frontdoor.waf_acl_name
+  webapp_ecs_task_role_name      = module.ecr.webapp_ecs_task_role_name
 }
 
 module "scheduled_tasks" {

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -122,6 +122,10 @@ locals {
       name  = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"
       value = data.aws_ssm_parameter.beta_feedback_team_email_address.value
     },
+    {
+      name  = "METRICS_CLOUDWATCH_NAMESPACE"
+      value = "prsdb-webapp/${local.environment_name}"
+    },
   ]
   # We set default Spring profiles for scheduled tasks to allow the application to correctly handle the case where a scheduled task is created without a dedicated profile. These should always be overridden by task-specific profiles.
   scheduled_tasks_only_environment_variables = [

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -126,6 +126,10 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "BPL_JVM_LOADED_CLASS_COUNT"
+      value = "40000"
+    },
   ]
   # We set default Spring profiles for scheduled tasks to allow the application to correctly handle the case where a scheduled task is created without a dedicated profile. These should always be overridden by task-specific profiles.
   scheduled_tasks_only_environment_variables = [

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -250,6 +250,7 @@ module "monitoring" {
   database_allocated_storage     = local.database_allocated_storage
   database_identifier            = module.database.database_identifier
   waf_acl_name                   = module.frontdoor.waf_acl_name
+  webapp_ecs_task_role_name      = module.ecr.webapp_ecs_task_role_name
 }
 
 module "scheduled_tasks" {

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -181,7 +181,7 @@ module "webapp_ecs_task_definition" {
   ecs_task_role_arn           = data.aws_iam_role.webapp_ecs_task.arn
   # TODO: consider what our requirements are for the instance
   task_cpu              = 512
-  task_memory           = 1024
+  task_memory           = 2048
   task_name             = "prsdb-webapp"
   environment_variables = concat(local.common_environment_variables, local.webapp_only_environment_variables)
   secrets               = concat(local.common_secrets, local.webapp_secrets)

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -122,6 +122,10 @@ locals {
       name  = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"
       value = data.aws_ssm_parameter.beta_feedback_team_email_address.value
     },
+    {
+      name  = "METRICS_CLOUDWATCH_NAMESPACE"
+      value = "prsdb-webapp/${local.environment_name}"
+    },
   ]
   # We set default Spring profiles for scheduled tasks to allow the application to correctly handle the case where a scheduled task is created without a dedicated profile. These should always be overridden by task-specific profiles.
   scheduled_tasks_only_environment_variables = [

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -126,6 +126,10 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "BPL_JVM_LOADED_CLASS_COUNT"
+      value = "40000"
+    },
   ]
   # We set default Spring profiles for scheduled tasks to allow the application to correctly handle the case where a scheduled task is created without a dedicated profile. These should always be overridden by task-specific profiles.
   scheduled_tasks_only_environment_variables = [

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -250,6 +250,7 @@ module "monitoring" {
   database_allocated_storage     = local.database_allocated_storage
   database_identifier            = module.database.database_identifier
   waf_acl_name                   = module.frontdoor.waf_acl_name
+  webapp_ecs_task_role_name      = module.ecr.webapp_ecs_task_role_name
 }
 
 module "scheduled_tasks" {


### PR DESCRIPTION
## Release notes

PDJB-NONE: Configure CloudWatch metric publishing for webapp tasks, Increase Paketo class count budget to raise Metaspace cap, Bump webapp Fargate task memory to 2 GiB
