### PR TITLE
PDJB-NONE: add METRICS_CLOUDWATCH_NAMESPACE to scheduled tasks

### DIFF
--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -60,6 +60,10 @@ locals {
       name  = "EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY"
       value = contains(["production"], local.environment_name) ? "true" : "false"
     },
+    {
+      name  = "METRICS_CLOUDWATCH_NAMESPACE"
+      value = "prsdb-webapp/${local.environment_name}"
+    },
   ]
   webapp_only_environment_variables = [
     {
@@ -123,8 +127,8 @@ locals {
       value = data.aws_ssm_parameter.beta_feedback_team_email_address.value
     },
     {
-      name  = "METRICS_CLOUDWATCH_NAMESPACE"
-      value = "prsdb-webapp/${local.environment_name}"
+      name  = "BPL_JVM_LOADED_CLASS_COUNT"
+      value = "40000"
     },
   ]
   # We set default Spring profiles for scheduled tasks to allow the application to correctly handle the case where a scheduled task is created without a dedicated profile. These should always be overridden by task-specific profiles.

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -60,6 +60,10 @@ locals {
       name  = "EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY"
       value = contains(["production"], local.environment_name) ? "true" : "false"
     },
+    {
+      name  = "METRICS_CLOUDWATCH_NAMESPACE"
+      value = "prsdb-webapp/${local.environment_name}"
+    },
   ]
   webapp_only_environment_variables = [
     {
@@ -121,10 +125,6 @@ locals {
     {
       name  = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"
       value = data.aws_ssm_parameter.beta_feedback_team_email_address.value
-    },
-    {
-      name  = "METRICS_CLOUDWATCH_NAMESPACE"
-      value = "prsdb-webapp/${local.environment_name}"
     },
     {
       name  = "BPL_JVM_LOADED_CLASS_COUNT"

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -60,6 +60,10 @@ locals {
       name  = "EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY"
       value = contains(["production"], local.environment_name) ? "true" : "false"
     },
+    {
+      name  = "METRICS_CLOUDWATCH_NAMESPACE"
+      value = "prsdb-webapp/${local.environment_name}"
+    },
   ]
   webapp_only_environment_variables = [
     {
@@ -121,10 +125,6 @@ locals {
     {
       name  = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"
       value = data.aws_ssm_parameter.beta_feedback_team_email_address.value
-    },
-    {
-      name  = "METRICS_CLOUDWATCH_NAMESPACE"
-      value = "prsdb-webapp/${local.environment_name}"
     },
     {
       name  = "BPL_JVM_LOADED_CLASS_COUNT"

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -60,6 +60,10 @@ locals {
       name  = "EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY"
       value = contains(["production"], local.environment_name) ? "true" : "false"
     },
+    {
+      name  = "METRICS_CLOUDWATCH_NAMESPACE"
+      value = "prsdb-webapp/${local.environment_name}"
+    },
   ]
   webapp_only_environment_variables = [
     {
@@ -121,10 +125,6 @@ locals {
     {
       name  = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"
       value = data.aws_ssm_parameter.beta_feedback_team_email_address.value
-    },
-    {
-      name  = "METRICS_CLOUDWATCH_NAMESPACE"
-      value = "prsdb-webapp/${local.environment_name}"
     },
     {
       name  = "BPL_JVM_LOADED_CLASS_COUNT"

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -60,6 +60,10 @@ locals {
       name  = "EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY"
       value = contains(["production"], local.environment_name) ? "true" : "false"
     },
+    {
+      name  = "METRICS_CLOUDWATCH_NAMESPACE"
+      value = "prsdb-webapp/${local.environment_name}"
+    },
   ]
   webapp_only_environment_variables = [
     {
@@ -121,10 +125,6 @@ locals {
     {
       name  = "BETA_FEEDBACK_TEAM_EMAIL_ADDRESS"
       value = data.aws_ssm_parameter.beta_feedback_team_email_address.value
-    },
-    {
-      name  = "METRICS_CLOUDWATCH_NAMESPACE"
-      value = "prsdb-webapp/${local.environment_name}"
     },
     {
       name  = "BPL_JVM_LOADED_CLASS_COUNT"


### PR DESCRIPTION

## Ticket number

PDJB-NONE

## Goal of change

Fix running of scheduled tasks

## Description of main change(s)

Scheduled tasks were failing with the error
```Caused by: org.springframework.util.PlaceholderResolutionException: Could not resolve placeholder 'METRICS_CLOUDWATCH_NAMESPACE' in value "${METRICS_CLOUDWATCH_NAMESPACE}"```

This should make `METRICS_CLOUDWATCH_NAMESPACE` available to scheduled tasks as well as webapp

## Anything you'd like to highlight to the reviewer?


## Checklist
Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done
