### PR TITLE
PDJB-190: Rate-limit probing traffic and split alarm SNS topics by severity

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -22,7 +22,8 @@ permissions:
 
 env:
   AWS_REGION: "eu-west-2"
-  TF_VAR_alarm_email_address: ${{ secrets.ALARMS_EMAIL }}
+  TF_VAR_critical_alarm_email_address: ${{ secrets.CRITICAL_ALARMS_EMAIL }}
+  TF_VAR_non_critical_alarm_email_address: ${{ secrets.NON_CRITICAL_ALARMS_EMAIL }}
   TF_VAR_maintenance_mode_on: ${{ inputs.maintenance-mode-on }}
   TF_VAR_ip_restrictions_on: ${{ inputs.ip-restrictions-on }}
 

--- a/.github/workflows/check-and-plan.yml
+++ b/.github/workflows/check-and-plan.yml
@@ -10,7 +10,8 @@ on:
         type: string
 
 env:
-  TF_VAR_alarm_email_address: ${{ secrets.ALARMS_EMAIL }}
+  TF_VAR_critical_alarm_email_address: ${{ secrets.CRITICAL_ALARMS_EMAIL }}
+  TF_VAR_non_critical_alarm_email_address: ${{ secrets.NON_CRITICAL_ALARMS_EMAIL }}
 
 jobs:
   validate-target-environment:

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -240,7 +240,7 @@ Get the One-Login admin to add these for each of the cloudfront domains used abo
 - If the output of the plan looks correct, run `terraform apply` to create the pre-requisite resources.
 - Terraform will create the webapp secrets and SSM parameters but (apart from those related to the database and Redis) will not populate them. Ask the team lead where you can find the appropriate values, and then populate them via the AWS console.
   - For Notify, this will involve creating a new API Key to use for the new environment.
-  - You will also need to add a new environment secret in Github called `ALARMS_EMAIL` with the email address to use for alarms in the new environment.
+  - You will also need to add two new environment secrets in Github: `CRITICAL_ALARMS_EMAIL` and `NON_CRITICAL_ALARMS_EMAIL`, each with the email address to use for the respective alarm severity in the new environment.
 - To create the task definition, in `terraform/<environment name>/ecs_task_definition`, if you haven't already, remove the `.template` from the end of any file names in the folder, and replace all instances of the string `<environment name>` with your actual environment name.
 - In `terraform/<environment name>/ecs_task_definition/terraform.tfvars`, set the `file_upload_created` variable to `false`.
 - Next, cd into `terraform/<environment name>/ecs_task_definition` and run `terraform init` followed by `terraform plan`. This should show you one resource being created - the task definition. If the output looks correct, run `terraform apply`.

--- a/terraform/environment_template/main.tf.template
+++ b/terraform/environment_template/main.tf.template
@@ -231,7 +231,6 @@ module "monitoring" {
   elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)
   database_allocated_storage     = local.database_allocated_storage
   database_identifier            = module.database.database_identifier
-  waf_acl_name                   = module.frontdoor.waf_acl_name
   webapp_ecs_task_role_name      = module.ecr.webapp_ecs_task_role_name
 }
 

--- a/terraform/environment_template/main.tf.template
+++ b/terraform/environment_template/main.tf.template
@@ -221,8 +221,9 @@ module "monitoring" {
   }
 
   environment_name               = local.environment_name
-  cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
-  alarm_email_address            = var.alarm_email_address
+  cloudwatch_log_expiration_days   = local.cloudwatch_log_expiration_days
+  critical_alarm_email_address     = var.critical_alarm_email_address
+  non_critical_alarm_email_address = var.non_critical_alarm_email_address
   alb_name                       = module.frontdoor.load_balancer.name
   alb_arn_suffix                 = module.frontdoor.load_balancer.arn_suffix
   alb_target_group_arn_suffix    = module.frontdoor.load_balancer.target_group_arn_suffix
@@ -243,5 +244,5 @@ module "scheduled_tasks" {
   schedule_expressions    = local.scheduled_tasks
   task_role_arn           = module.ecr.webapp_ecs_task_role_arn
   task_execution_role_arn = module.ecr.ecs_task_execution_role_arn
-  alarm_email_address     = var.alarm_email_address
+  alarm_email_address     = var.non_critical_alarm_email_address
 }

--- a/terraform/environment_template/variables.tf.template
+++ b/terraform/environment_template/variables.tf.template
@@ -10,8 +10,14 @@ variable "task_definition_created" {
   default     = true
 }
 
-variable "alarm_email_address" {
-  description = "Email addresses to receive CloudWatch alarm notifications"
+variable "critical_alarm_email_address" {
+  description = "Email address to receive critical CloudWatch alarm notifications"
+  type        = string
+  sensitive   = true
+}
+
+variable "non_critical_alarm_email_address" {
+  description = "Email address to receive non-critical CloudWatch alarm notifications"
   type        = string
   sensitive   = true
 }

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -250,7 +250,6 @@ module "monitoring" {
   elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)
   database_allocated_storage     = local.database_allocated_storage
   database_identifier            = module.database.database_identifier
-  waf_acl_name                   = module.frontdoor.waf_acl_name
   webapp_ecs_task_role_name      = module.ecr.webapp_ecs_task_role_name
 }
 

--- a/terraform/integration/main.tf
+++ b/terraform/integration/main.tf
@@ -239,18 +239,19 @@ module "monitoring" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  environment_name               = local.environment_name
-  cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
-  alarm_email_address            = var.alarm_email_address
-  alb_name                       = module.frontdoor.load_balancer.name
-  alb_arn_suffix                 = module.frontdoor.load_balancer.arn_suffix
-  alb_target_group_arn_suffix    = module.frontdoor.load_balancer.target_group_arn_suffix
-  ecs_cluster_name               = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
-  ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
-  elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)
-  database_allocated_storage     = local.database_allocated_storage
-  database_identifier            = module.database.database_identifier
-  webapp_ecs_task_role_name      = module.ecr.webapp_ecs_task_role_name
+  environment_name                 = local.environment_name
+  cloudwatch_log_expiration_days   = local.cloudwatch_log_expiration_days
+  critical_alarm_email_address     = var.critical_alarm_email_address
+  non_critical_alarm_email_address = var.non_critical_alarm_email_address
+  alb_name                         = module.frontdoor.load_balancer.name
+  alb_arn_suffix                   = module.frontdoor.load_balancer.arn_suffix
+  alb_target_group_arn_suffix      = module.frontdoor.load_balancer.target_group_arn_suffix
+  ecs_cluster_name                 = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
+  ecs_service_name                 = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
+  elasticache_cluster_ids          = toset(module.redis.redis_cluster_ids)
+  database_allocated_storage       = local.database_allocated_storage
+  database_identifier              = module.database.database_identifier
+  webapp_ecs_task_role_name        = module.ecr.webapp_ecs_task_role_name
 }
 
 module "scheduled_tasks" {
@@ -262,5 +263,5 @@ module "scheduled_tasks" {
   schedule_expressions    = local.scheduled_tasks
   task_role_arn           = module.ecr.webapp_ecs_task_role_arn
   task_execution_role_arn = module.ecr.ecs_task_execution_role_arn
-  alarm_email_address     = var.alarm_email_address
+  alarm_email_address     = var.non_critical_alarm_email_address
 }

--- a/terraform/integration/variables.tf
+++ b/terraform/integration/variables.tf
@@ -10,8 +10,14 @@ variable "task_definition_created" {
   default     = true
 }
 
-variable "alarm_email_address" {
-  description = "Email addresses to receive CloudWatch alarm notifications"
+variable "critical_alarm_email_address" {
+  description = "Email address to receive critical CloudWatch alarm notifications"
+  type        = string
+  sensitive   = true
+}
+
+variable "non_critical_alarm_email_address" {
+  description = "Email address to receive non-critical CloudWatch alarm notifications"
   type        = string
   sensitive   = true
 }

--- a/terraform/modules/frontdoor/cloudfront.tf
+++ b/terraform/modules/frontdoor/cloudfront.tf
@@ -1,6 +1,24 @@
 locals {
   origin_id             = "origin-${var.environment_name}"
   maintenance_origin_id = "maintenance-origin-${var.environment_name}"
+
+  # Single source of truth for the URL rewriter exception path segments. The same list is rendered into url_rewriter.js
+  # at deploy time and used to build the CloudFront WAF's "unknown paths" rate-limit allowlist regex below, so the two
+  # can never drift.
+  url_rewriter_exceptions = jsondecode(file("${path.module}/url_rewriter_exceptions.json"))
+
+  # Service segments that the URL rewriter inserts based on the request hostname. Real traffic always reaches the
+  # application via either an exception path or one of these segments, so we allow them in the WAF allowlist too.
+  # These remain duplicated in url_rewriter.js as their handling is intertwined with host-specific logic.
+  url_rewriter_service_segments = ["landlord", "local-council"]
+
+  allowed_top_level_path_segments = concat(local.url_rewriter_exceptions, local.url_rewriter_service_segments)
+
+  # Regex matching either "/" or any URI whose first path segment is in the allowlist (case-sensitive).
+  unknown_path_allowlist_regex = format(
+    "^/$|^/(%s)(/|$)",
+    join("|", [for s in local.allowed_top_level_path_segments : replace(s, ".", "\\.")])
+  )
 }
 
 resource "aws_cloudfront_origin_access_identity" "maintenance_oai" {
@@ -198,7 +216,9 @@ resource "aws_cloudfront_function" "url_rewriter" {
   runtime = "cloudfront-js-2.0"
   comment = "Rewrites URLs to include the service line as the first path segment"
   publish = true
-  code    = file("${path.module}/url_rewriter.js")
+  code = templatefile("${path.module}/url_rewriter.js.tftpl", {
+    exceptions = local.url_rewriter_exceptions
+  })
 }
 
 resource "aws_shield_subscription" "cloudfront" {

--- a/terraform/modules/frontdoor/cloudfront_waf.tf
+++ b/terraform/modules/frontdoor/cloudfront_waf.tf
@@ -399,7 +399,7 @@ resource "aws_wafv2_web_acl" "main" {
                 }
                 text_transformation {
                   priority = 0
-                  type     = "LOWERCASE"
+                  type     = "NONE"
                 }
               }
             }

--- a/terraform/modules/frontdoor/cloudfront_waf.tf
+++ b/terraform/modules/frontdoor/cloudfront_waf.tf
@@ -393,7 +393,7 @@ resource "aws_wafv2_web_acl" "main" {
           not_statement {
             statement {
               regex_match_statement {
-                regex_string = "^/$|^/(signout|confirm-sign-out|error|assets|id-verification|logout|oauth2|login|healthcheck|cookies|maintenance|\\.well-known|system-operator|landlord|local-council)(/|$)"
+                regex_string = local.unknown_path_allowlist_regex
                 field_to_match {
                   uri_path {}
                 }

--- a/terraform/modules/frontdoor/cloudfront_waf.tf
+++ b/terraform/modules/frontdoor/cloudfront_waf.tf
@@ -366,6 +366,54 @@ resource "aws_wafv2_web_acl" "main" {
       sampled_requests_enabled   = true
     }
   }
+
+  rule {
+    name = "rate-limit-unknown-paths"
+    # Allowed top-level path segments mirror those handled by the CloudFront URL rewriter
+    # (terraform/modules/frontdoor/url_rewriter.js): exceptions allowed through unchanged,
+    # plus the "landlord" / "local-council" segments inserted by the rewriter. Any other
+    # top-level segment is treated as a probe and IPs exceeding the limit are blocked.
+    priority = 12
+
+    action {
+      block {
+        custom_response {
+          response_code = 429
+        }
+      }
+    }
+
+    statement {
+      rate_based_statement {
+        aggregate_key_type    = "IP"
+        limit                 = 100
+        evaluation_window_sec = 300
+
+        scope_down_statement {
+          not_statement {
+            statement {
+              regex_match_statement {
+                regex_string = "^/$|^/(signout|confirm-sign-out|error|assets|id-verification|logout|oauth2|login|healthcheck|cookies|maintenance|\\.well-known|system-operator|landlord|local-council)(/|$)"
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "waf-rate-limit-unknown-paths"
+      sampled_requests_enabled   = true
+    }
+  }
 }
 
 resource "aws_wafv2_ip_set" "allowed_ips" {

--- a/terraform/modules/frontdoor/url_rewriter.js.tftpl
+++ b/terraform/modules/frontdoor/url_rewriter.js.tftpl
@@ -1,5 +1,5 @@
 function handler(event) {
-    const exceptions = ["signout","confirm-sign-out", "error", "assets", "id-verification", "logout", "oauth2", "login", "healthcheck", "cookies", "maintenance", ".well-known", "system-operator"];
+    const exceptions = ${jsonencode(exceptions)};
     const request = event.request;
     const hostName = request.headers.host.value;
     let pathSegments = request.uri.split('/');

--- a/terraform/modules/frontdoor/url_rewriter_exceptions.json
+++ b/terraform/modules/frontdoor/url_rewriter_exceptions.json
@@ -1,0 +1,15 @@
+[
+  "signout",
+  "confirm-sign-out",
+  "error",
+  "assets",
+  "id-verification",
+  "logout",
+  "oauth2",
+  "login",
+  "healthcheck",
+  "cookies",
+  "maintenance",
+  ".well-known",
+  "system-operator"
+]

--- a/terraform/modules/monitoring/application_alarms.tf
+++ b/terraform/modules/monitoring/application_alarms.tf
@@ -11,6 +11,6 @@ resource "aws_cloudwatch_metric_alarm" "virus_scan_failure" {
   treat_missing_data  = "notBreaching"
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.non_critical_alarm_sns_topic.arn,
   ]
 }

--- a/terraform/modules/monitoring/cloudtrail_alarms.tf
+++ b/terraform/modules/monitoring/cloudtrail_alarms.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "assume_role_with_saml" {
   statistic           = "Sum"
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -28,7 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
   statistic           = "Sum"
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -45,7 +45,7 @@ resource "aws_cloudwatch_metric_alarm" "iam_policy_changes" {
   statistic           = "Sum"
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -62,7 +62,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudtrail_config_changes" {
   statistic           = "Sum"
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -79,7 +79,7 @@ resource "aws_cloudwatch_metric_alarm" "s3_bucket_policy_changes" {
   statistic           = "Sum"
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -96,7 +96,7 @@ resource "aws_cloudwatch_metric_alarm" "network_gateway_changes" {
   statistic           = "Sum"
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -113,7 +113,7 @@ resource "aws_cloudwatch_metric_alarm" "route_tables_changes" {
   statistic           = "Sum"
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -130,7 +130,7 @@ resource "aws_cloudwatch_metric_alarm" "vpc_changes" {
   statistic           = "Sum"
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -147,6 +147,6 @@ resource "aws_cloudwatch_metric_alarm" "organization_changes" {
   statistic           = "Sum"
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.critical_alarm_sns_topic.arn,
   ]
 }

--- a/terraform/modules/monitoring/iam.tf
+++ b/terraform/modules/monitoring/iam.tf
@@ -46,19 +46,52 @@ resource "aws_iam_role_policy_attachment" "cloudtrail_cloudwatch_policy_attachme
   policy_arn = aws_iam_policy.cloudtrail_cloudwatch_policy.arn
 }
 
-resource "aws_sns_topic_policy" "cloudwatch_to_alarm_sns" {
-  arn    = aws_sns_topic.alarm_sns_topic.arn
-  policy = data.aws_iam_policy_document.cloudwatch_to_sns_policy_document.json
+resource "aws_sns_topic_policy" "cloudwatch_to_critical_alarm_sns" {
+  arn    = aws_sns_topic.critical_alarm_sns_topic.arn
+  policy = data.aws_iam_policy_document.cloudwatch_to_critical_sns_policy_document.json
 }
 
-data "aws_iam_policy_document" "cloudwatch_to_sns_policy_document" {
+resource "aws_sns_topic_policy" "cloudwatch_to_non_critical_alarm_sns" {
+  arn    = aws_sns_topic.non_critical_alarm_sns_topic.arn
+  policy = data.aws_iam_policy_document.cloudwatch_to_non_critical_sns_policy_document.json
+}
+
+moved {
+  from = aws_sns_topic_policy.cloudwatch_to_alarm_sns
+  to   = aws_sns_topic_policy.cloudwatch_to_critical_alarm_sns
+}
+
+data "aws_iam_policy_document" "cloudwatch_to_critical_sns_policy_document" {
   statement {
     effect = "Allow"
     actions = [
       "sns:Publish"
     ]
     resources = [
-      aws_sns_topic.alarm_sns_topic.arn
+      aws_sns_topic.critical_alarm_sns_topic.arn
+    ]
+    principals {
+      type = "Service"
+      identifiers = [
+        "cloudwatch.amazonaws.com"
+      ]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cloudwatch_to_non_critical_sns_policy_document" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sns:Publish"
+    ]
+    resources = [
+      aws_sns_topic.non_critical_alarm_sns_topic.arn
     ]
     principals {
       type = "Service"

--- a/terraform/modules/monitoring/resource_alarms.tf
+++ b/terraform/modules/monitoring/resource_alarms.tf
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpu_usage" {
   }
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.non_critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -36,7 +36,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_memory_usage" {
   }
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.non_critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -53,7 +53,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_task_start_failure" {
   treat_missing_data  = "notBreaching"
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.non_critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -73,7 +73,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu_usage" {
   }
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.non_critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -93,7 +93,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_storage" {
   }
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.non_critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -115,7 +115,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_cpu_usage" {
   }
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.non_critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -137,7 +137,7 @@ resource "aws_cloudwatch_metric_alarm" "elasticache_memory_usage" {
   }
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.non_critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -158,7 +158,7 @@ resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
   }
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.non_critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -179,7 +179,7 @@ resource "aws_cloudwatch_metric_alarm" "alb_4xx_errors" {
   }
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.non_critical_alarm_sns_topic.arn,
   ]
 }
 
@@ -200,6 +200,6 @@ resource "aws_cloudwatch_metric_alarm" "alb_no_healthy_hosts" {
   }
 
   alarm_actions = [
-    aws_sns_topic.alarm_sns_topic.arn,
+    aws_sns_topic.critical_alarm_sns_topic.arn,
   ]
 }

--- a/terraform/modules/monitoring/resource_alarms.tf
+++ b/terraform/modules/monitoring/resource_alarms.tf
@@ -164,13 +164,13 @@ resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
 
 resource "aws_cloudwatch_metric_alarm" "alb_4xx_errors" {
   alarm_name          = "${var.alb_name}-4xx-errors"
-  alarm_description   = "There have been >100 4xx responses at the ALB in a minute"
+  alarm_description   = "There have been >500 4xx responses at the ALB in 5 minutes"
   comparison_operator = "GreaterThanThreshold"
   metric_name         = "HTTPCode_Target_4XX_Count"
   namespace           = "AWS/ApplicationELB"
   evaluation_periods  = 1
-  period              = 60
-  threshold           = 100
+  period              = 300
+  threshold           = 500
   statistic           = "Sum"
   treat_missing_data  = "notBreaching"
 
@@ -201,28 +201,5 @@ resource "aws_cloudwatch_metric_alarm" "alb_no_healthy_hosts" {
 
   alarm_actions = [
     aws_sns_topic.alarm_sns_topic.arn,
-  ]
-}
-
-resource "aws_cloudwatch_metric_alarm" "waf_blocked_requests" {
-  alarm_name          = "${var.waf_acl_name}-blocked-requests"
-  alarm_description   = "There have been >100 blocked WAF requests in a minute"
-  comparison_operator = "GreaterThanThreshold"
-  metric_name         = "BlockedRequests"
-  namespace           = "AWS/WAFV2"
-  evaluation_periods  = 1
-  period              = 60
-  threshold           = 100
-  statistic           = "Sum"
-  treat_missing_data  = "notBreaching"
-  provider            = aws.us-east-1
-
-  dimensions = {
-    Rule   = "ALL"
-    WebACL = var.waf_acl_name
-  }
-
-  alarm_actions = [
-    aws_sns_topic.us_alarm_sns_topic.arn,
   ]
 }

--- a/terraform/modules/monitoring/sns.tf
+++ b/terraform/modules/monitoring/sns.tf
@@ -1,27 +1,35 @@
 # non-sensitive
 # tfsec:ignore:aws-sns-enable-topic-encryption
-resource "aws_sns_topic" "alarm_sns_topic" {
-  name         = "${var.environment_name}-alarm-sns-topic"
-  display_name = "Notifications for cloudwatch alarms in ${var.environment_name} environment"
+resource "aws_sns_topic" "critical_alarm_sns_topic" {
+  name         = "${var.environment_name}-critical-alarm-sns-topic"
+  display_name = "Notifications for critical cloudwatch alarms in ${var.environment_name} environment"
 }
 
-resource "aws_sns_topic_subscription" "alarm_email_subscription" {
-  topic_arn = aws_sns_topic.alarm_sns_topic.arn
+resource "aws_sns_topic_subscription" "critical_alarm_email_subscription" {
+  topic_arn = aws_sns_topic.critical_alarm_sns_topic.arn
   protocol  = "email"
-  endpoint  = var.alarm_email_address
+  endpoint  = var.critical_alarm_email_address
 }
 
 # non-sensitive
 # tfsec:ignore:aws-sns-enable-topic-encryption
-resource "aws_sns_topic" "us_alarm_sns_topic" {
-  name         = "${var.environment_name}-us-alarm-sns-topic"
-  display_name = "Notifications for cloudwatch alarms in ${var.environment_name} environment and us-east-1 region"
-  provider     = aws.us-east-1
+resource "aws_sns_topic" "non_critical_alarm_sns_topic" {
+  name         = "${var.environment_name}-non-critical-alarm-sns-topic"
+  display_name = "Notifications for non-critical cloudwatch alarms in ${var.environment_name} environment"
 }
 
-resource "aws_sns_topic_subscription" "us_alarm_email_subscription" {
-  topic_arn = aws_sns_topic.us_alarm_sns_topic.arn
+resource "aws_sns_topic_subscription" "non_critical_alarm_email_subscription" {
+  topic_arn = aws_sns_topic.non_critical_alarm_sns_topic.arn
   protocol  = "email"
-  endpoint  = var.alarm_email_address
-  provider  = aws.us-east-1
+  endpoint  = var.non_critical_alarm_email_address
+}
+
+moved {
+  from = aws_sns_topic.alarm_sns_topic
+  to   = aws_sns_topic.critical_alarm_sns_topic
+}
+
+moved {
+  from = aws_sns_topic_subscription.alarm_email_subscription
+  to   = aws_sns_topic_subscription.critical_alarm_email_subscription
 }

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -7,8 +7,13 @@ variable "environment_name" {
   }
 }
 
-variable "alarm_email_address" {
-  description = "Email address to receive CloudWatch alarm notifications"
+variable "critical_alarm_email_address" {
+  description = "Email address to receive critical CloudWatch alarm notifications"
+  type        = string
+}
+
+variable "non_critical_alarm_email_address" {
+  description = "Email address to receive non-critical CloudWatch alarm notifications"
   type        = string
 }
 

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -57,11 +57,6 @@ variable "alb_target_group_arn_suffix" {
   type        = string
 }
 
-variable "waf_acl_name" {
-  description = "Name of WAF web ACL to create alarms for"
-  type        = string
-}
-
 variable "webapp_ecs_task_role_name" {
   description = "Name of the webapp ECS task role to grant CloudWatch metric publishing permissions to"
   type        = string

--- a/terraform/nft/main.tf
+++ b/terraform/nft/main.tf
@@ -243,18 +243,19 @@ module "monitoring" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  environment_name               = local.environment_name
-  cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
-  alarm_email_address            = var.alarm_email_address
-  alb_name                       = module.frontdoor.load_balancer.name
-  alb_arn_suffix                 = module.frontdoor.load_balancer.arn_suffix
-  alb_target_group_arn_suffix    = module.frontdoor.load_balancer.target_group_arn_suffix
-  ecs_cluster_name               = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
-  ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
-  elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)
-  database_allocated_storage     = local.database_allocated_storage
-  database_identifier            = module.database.database_identifier
-  webapp_ecs_task_role_name      = module.ecr.webapp_ecs_task_role_name
+  environment_name                 = local.environment_name
+  cloudwatch_log_expiration_days   = local.cloudwatch_log_expiration_days
+  critical_alarm_email_address     = var.critical_alarm_email_address
+  non_critical_alarm_email_address = var.non_critical_alarm_email_address
+  alb_name                         = module.frontdoor.load_balancer.name
+  alb_arn_suffix                   = module.frontdoor.load_balancer.arn_suffix
+  alb_target_group_arn_suffix      = module.frontdoor.load_balancer.target_group_arn_suffix
+  ecs_cluster_name                 = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
+  ecs_service_name                 = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
+  elasticache_cluster_ids          = toset(module.redis.redis_cluster_ids)
+  database_allocated_storage       = local.database_allocated_storage
+  database_identifier              = module.database.database_identifier
+  webapp_ecs_task_role_name        = module.ecr.webapp_ecs_task_role_name
 }
 
 module "scheduled_tasks" {
@@ -266,5 +267,5 @@ module "scheduled_tasks" {
   schedule_expressions    = local.scheduled_tasks
   task_role_arn           = module.ecr.webapp_ecs_task_role_arn
   task_execution_role_arn = module.ecr.ecs_task_execution_role_arn
-  alarm_email_address     = var.alarm_email_address
+  alarm_email_address     = var.non_critical_alarm_email_address
 }

--- a/terraform/nft/main.tf
+++ b/terraform/nft/main.tf
@@ -254,7 +254,6 @@ module "monitoring" {
   elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)
   database_allocated_storage     = local.database_allocated_storage
   database_identifier            = module.database.database_identifier
-  waf_acl_name                   = module.frontdoor.waf_acl_name
   webapp_ecs_task_role_name      = module.ecr.webapp_ecs_task_role_name
 }
 

--- a/terraform/nft/variables.tf
+++ b/terraform/nft/variables.tf
@@ -10,8 +10,14 @@ variable "task_definition_created" {
   default     = true
 }
 
-variable "alarm_email_address" {
-  description = "Email addresses to receive CloudWatch alarm notifications"
+variable "critical_alarm_email_address" {
+  description = "Email address to receive critical CloudWatch alarm notifications"
+  type        = string
+  sensitive   = true
+}
+
+variable "non_critical_alarm_email_address" {
+  description = "Email address to receive non-critical CloudWatch alarm notifications"
   type        = string
   sensitive   = true
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -238,18 +238,19 @@ module "monitoring" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  environment_name               = local.environment_name
-  cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
-  alarm_email_address            = var.alarm_email_address
-  alb_name                       = module.frontdoor.load_balancer.name
-  alb_arn_suffix                 = module.frontdoor.load_balancer.arn_suffix
-  alb_target_group_arn_suffix    = module.frontdoor.load_balancer.target_group_arn_suffix
-  ecs_cluster_name               = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
-  ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
-  elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)
-  database_allocated_storage     = local.database_allocated_storage
-  database_identifier            = module.database.database_identifier
-  webapp_ecs_task_role_name      = module.ecr.webapp_ecs_task_role_name
+  environment_name                 = local.environment_name
+  cloudwatch_log_expiration_days   = local.cloudwatch_log_expiration_days
+  critical_alarm_email_address     = var.critical_alarm_email_address
+  non_critical_alarm_email_address = var.non_critical_alarm_email_address
+  alb_name                         = module.frontdoor.load_balancer.name
+  alb_arn_suffix                   = module.frontdoor.load_balancer.arn_suffix
+  alb_target_group_arn_suffix      = module.frontdoor.load_balancer.target_group_arn_suffix
+  ecs_cluster_name                 = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
+  ecs_service_name                 = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
+  elasticache_cluster_ids          = toset(module.redis.redis_cluster_ids)
+  database_allocated_storage       = local.database_allocated_storage
+  database_identifier              = module.database.database_identifier
+  webapp_ecs_task_role_name        = module.ecr.webapp_ecs_task_role_name
 }
 
 module "scheduled_tasks" {
@@ -261,5 +262,5 @@ module "scheduled_tasks" {
   schedule_expressions    = local.scheduled_tasks
   task_role_arn           = module.ecr.webapp_ecs_task_role_arn
   task_execution_role_arn = module.ecr.ecs_task_execution_role_arn
-  alarm_email_address     = var.alarm_email_address
+  alarm_email_address     = var.non_critical_alarm_email_address
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -249,7 +249,6 @@ module "monitoring" {
   elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)
   database_allocated_storage     = local.database_allocated_storage
   database_identifier            = module.database.database_identifier
-  waf_acl_name                   = module.frontdoor.waf_acl_name
   webapp_ecs_task_role_name      = module.ecr.webapp_ecs_task_role_name
 }
 

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -10,8 +10,14 @@ variable "task_definition_created" {
   default     = true
 }
 
-variable "alarm_email_address" {
-  description = "Email address to receive CloudWatch alarm notifications"
+variable "critical_alarm_email_address" {
+  description = "Email address to receive critical CloudWatch alarm notifications"
+  type        = string
+  sensitive   = true
+}
+
+variable "non_critical_alarm_email_address" {
+  description = "Email address to receive non-critical CloudWatch alarm notifications"
   type        = string
   sensitive   = true
 }

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -238,18 +238,19 @@ module "monitoring" {
     aws.us-east-1 = aws.us-east-1
   }
 
-  environment_name               = local.environment_name
-  cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
-  alarm_email_address            = var.alarm_email_address
-  alb_name                       = module.frontdoor.load_balancer.name
-  alb_arn_suffix                 = module.frontdoor.load_balancer.arn_suffix
-  alb_target_group_arn_suffix    = module.frontdoor.load_balancer.target_group_arn_suffix
-  ecs_cluster_name               = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
-  ecs_service_name               = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
-  elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)
-  database_allocated_storage     = local.database_allocated_storage
-  database_identifier            = module.database.database_identifier
-  webapp_ecs_task_role_name      = module.ecr.webapp_ecs_task_role_name
+  environment_name                 = local.environment_name
+  cloudwatch_log_expiration_days   = local.cloudwatch_log_expiration_days
+  critical_alarm_email_address     = var.critical_alarm_email_address
+  non_critical_alarm_email_address = var.non_critical_alarm_email_address
+  alb_name                         = module.frontdoor.load_balancer.name
+  alb_arn_suffix                   = module.frontdoor.load_balancer.arn_suffix
+  alb_target_group_arn_suffix      = module.frontdoor.load_balancer.target_group_arn_suffix
+  ecs_cluster_name                 = var.task_definition_created ? module.ecs_service[0].ecs_cluster_name : ""
+  ecs_service_name                 = var.task_definition_created ? module.ecs_service[0].ecs_service_name : ""
+  elasticache_cluster_ids          = toset(module.redis.redis_cluster_ids)
+  database_allocated_storage       = local.database_allocated_storage
+  database_identifier              = module.database.database_identifier
+  webapp_ecs_task_role_name        = module.ecr.webapp_ecs_task_role_name
 }
 
 module "scheduled_tasks" {
@@ -261,5 +262,5 @@ module "scheduled_tasks" {
   schedule_expressions    = local.scheduled_tasks
   task_role_arn           = module.ecr.webapp_ecs_task_role_arn
   task_execution_role_arn = module.ecr.ecs_task_execution_role_arn
-  alarm_email_address     = var.alarm_email_address
+  alarm_email_address     = var.non_critical_alarm_email_address
 }

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -249,7 +249,6 @@ module "monitoring" {
   elasticache_cluster_ids        = toset(module.redis.redis_cluster_ids)
   database_allocated_storage     = local.database_allocated_storage
   database_identifier            = module.database.database_identifier
-  waf_acl_name                   = module.frontdoor.waf_acl_name
   webapp_ecs_task_role_name      = module.ecr.webapp_ecs_task_role_name
 }
 

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -10,8 +10,14 @@ variable "task_definition_created" {
   default     = true
 }
 
-variable "alarm_email_address" {
-  description = "Email address to receive CloudWatch alarm notifications"
+variable "critical_alarm_email_address" {
+  description = "Email address to receive critical CloudWatch alarm notifications"
+  type        = string
+  sensitive   = true
+}
+
+variable "non_critical_alarm_email_address" {
+  description = "Email address to receive non-critical CloudWatch alarm notifications"
   type        = string
   sensitive   = true
 }

--- a/test/js/url_rewriter.test.js
+++ b/test/js/url_rewriter.test.js
@@ -1,5 +1,15 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const rewire = require('rewire');
-const url_rewriter = rewire('../../terraform/modules/frontdoor/url_rewriter.js').__get__('handler');
+
+const moduleDir = path.join(__dirname, '..', '..', 'terraform', 'modules', 'frontdoor');
+const exceptions = JSON.parse(fs.readFileSync(path.join(moduleDir, 'url_rewriter_exceptions.json'), 'utf8'));
+const template = fs.readFileSync(path.join(moduleDir, 'url_rewriter.js.tftpl'), 'utf8');
+const rendered = template.replace('${jsonencode(exceptions)}', JSON.stringify(exceptions));
+const renderedPath = path.join(os.tmpdir(), 'url_rewriter.rendered.js');
+fs.writeFileSync(renderedPath, rendered);
+const url_rewriter = rewire(renderedPath).__get__('handler');
 
 describe('url_rewriter', () => {
     it('returns the original url for a URL that does not include one of our domain names', () => {


### PR DESCRIPTION
## Ticket number

PDJB-190

## Goal of change

Review our CloudWatch alarms so that vulnerability-probing traffic is rate-limited at the WAF (rather than tripping the ALB 4xx alarm), the existing noisy WAF blocked-requests alarm is removed, and alarm notifications are split by severity onto separate SNS topics so we can route them to different addresses.

## Description of main change(s)

- Adds a new CloudFront WAF rule `rate-limit-unknown-paths` (priority 12) that blocks an IP with HTTP 429 after 100 requests per 5-minute window to URIs that are not `/` or one of the path segments handled by the CloudFront URL rewriter (`signout`, `confirm-sign-out`, `error`, `assets`, `id-verification`, `logout`, `oauth2`, `login`, `healthcheck`, `cookies`, `maintenance`, `.well-known`, `system-operator`, `landlord`, `local-council`). This targets vulnerability probing without affecting legitimate users.
- Tunes the ALB 4xx alarm to evaluate `>500 4xx responses in 5 minutes` (previously `>100 in 1 minute`). Same average sensitivity as before, but a single IP maxing the new rate limiter cannot trip it on its own.
- Removes the `${env}-waf-blocked-requests` alarm — it was paging on routine probing that the WAF had already blocked.
- Splits alarm notifications into two SNS topics per environment:
  - `${env}-critical-alarm-sns-topic` — all CloudTrail security alarms (SAML role assumption, unauthorized API calls, IAM/CloudTrail/S3/network/route-table/VPC/org changes) and `alb-no-healthy-hosts`.
  - `${env}-non-critical-alarm-sns-topic` — virus-scan failure, all ECS/RDS/ElastiCache resource alarms, ALB 5xx/4xx, and the scheduled-tasks DLQ alarm.
- Removes the now-unused `${env}-us-alarm-sns-topic` (its only consumer was the deleted blocked-requests alarm).
- Replaces the `alarm_email_address` Terraform variable / `ALARMS_EMAIL` GitHub secret with two pairs (`critical_alarm_email_address`/`CRITICAL_ALARMS_EMAIL` and `non_critical_alarm_email_address`/`NON_CRITICAL_ALARMS_EMAIL`); workflows and the new-environment ReadMe updated accordingly.

## Anything you'd like to highlight to the reviewer?

- The renamed SNS topic (`${env}-alarm-sns-topic` → `${env}-critical-alarm-sns-topic`) is handled via a `moved` block in Terraform, but because the AWS resource name changes the topic will be destroyed and recreated. New email subscriptions on both topics will need to be confirmed from the AWS-sent confirmation emails after apply.
- The two new GitHub environment secrets `CRITICAL_ALARMS_EMAIL` and `NON_CRITICAL_ALARMS_EMAIL` must be added to each environment before applying — the old `ALARMS_EMAIL` secret is no longer referenced.
- WAF rate-based rules re-evaluate roughly every 30 seconds, so a high-rate single IP can briefly send more than the limit before being blocked. The 500/5min ALB 4xx alarm threshold has headroom for this.

## Checklist

- [ ] After apply, confirm the new SNS topic email subscriptions in both regions.
- [ ] Add `CRITICAL_ALARMS_EMAIL` and `NON_CRITICAL_ALARMS_EMAIL` environment secrets in GitHub for every environment before merging / applying. Remove the legacy `ALARMS_EMAIL` secret once apply is complete.
