### PR TITLE
PDJB-1070: Add environment to scheduled tasks

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -277,6 +277,6 @@ To create a new scheduled task, you need to add an object to the relevant schedu
 
 Where schedule expression is a cron or rate expression as defined in the [AWS documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-scheduled-rule-pattern.html).
 
-This will trigger a copy of the webapp container in line with the schedule. The container will have the Spring profiles set to `web-server-deactivated`, `scheduled-task`, and `<name-of-task>-scheduled-task` which should be used to select the correct application runner in the webapp for this particular task.
+This will trigger a copy of the webapp container in line with the schedule. The container will have the Spring profiles set to `web-server-deactivated`, `scheduled-task`, `<environment>`, and `<name-of-task>-scheduled-task` which should be used to select the correct application runner in the webapp for this particular task in the correct environment.
 
 Our SSM maintenance window is 2-5am every Wednesday, so we should avoid scheduling tasks in that timeslot in case of disruption.

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -135,7 +135,7 @@ locals {
   scheduled_tasks_only_environment_variables = [
     {
       name  = "SPRING_PROFILES_ACTIVE"
-      value = "web-server-deactivated,scheduled-task"
+      value = "web-server-deactivated,scheduled-task,${local.environment_name}"
     },
   ]
   common_secrets = [

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -135,7 +135,7 @@ locals {
   scheduled_tasks_only_environment_variables = [
     {
       name  = "SPRING_PROFILES_ACTIVE"
-      value = "web-server-deactivated,scheduled-task"
+      value = "web-server-deactivated,scheduled-task,${local.environment_name}"
     },
   ]
   common_secrets = [

--- a/terraform/modules/scheduled_tasks/scheduler.tf
+++ b/terraform/modules/scheduled_tasks/scheduler.tf
@@ -37,7 +37,7 @@ resource "aws_scheduler_schedule" "scheduled_tasks" {
           "environment" : [
             {
               "name" : "SPRING_PROFILES_ACTIVE",
-              "value" : "web-server-deactivated,scheduled-task,${each.key}-scheduled-task"
+              "value" : "web-server-deactivated,scheduled-task,${var.environment_name},${each.key}-scheduled-task"
             }
           ]
         }

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -135,7 +135,7 @@ locals {
   scheduled_tasks_only_environment_variables = [
     {
       name  = "SPRING_PROFILES_ACTIVE"
-      value = "web-server-deactivated,scheduled-task"
+      value = "web-server-deactivated,scheduled-task,${local.environment_name}"
     },
   ]
   common_secrets = [

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -135,7 +135,7 @@ locals {
   scheduled_tasks_only_environment_variables = [
     {
       name  = "SPRING_PROFILES_ACTIVE"
-      value = "web-server-deactivated,scheduled-task"
+      value = "web-server-deactivated,scheduled-task,${local.environment_name}"
     },
   ]
   common_secrets = [

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -135,7 +135,7 @@ locals {
   scheduled_tasks_only_environment_variables = [
     {
       name  = "SPRING_PROFILES_ACTIVE"
-      value = "web-server-deactivated,scheduled-task"
+      value = "web-server-deactivated,scheduled-task,${local.environment_name}"
     },
   ]
   common_secrets = [


### PR DESCRIPTION
## Ticket number

[PDJB-1070](https://mhclgdigital.atlassian.net/browse/PDJB-1070)

## Goal of change

add the environment profile to scheduled tasks

## Description of main change(s)

fixes a bug where the scheduled jobs wouldn't have the environment profile and so wouldn't know to say, load environment specific config

## Anything you'd like to highlight to the reviewer?

I don't have terraform setup locally yet, though I'm fairly certain in this changeset as it's pretty minor