### PR TITLE
PDJB-269: add JL invite deletion tasks

### DIFF
--- a/terraform/environment_template/scheduled_tasks.json
+++ b/terraform/environment_template/scheduled_tasks.json
@@ -11,5 +11,8 @@
   },
   "jl-invitation-expiry-email": {
     "schedule_expression": "cron(0 7 * * ? *)"
+  },
+  "jl-invitation-deletion": {
+    "schedule_expression": "cron(0 1 * * ? *)"
   }
 }

--- a/terraform/integration/scheduled_tasks.json
+++ b/terraform/integration/scheduled_tasks.json
@@ -10,5 +10,8 @@
   },
   "jl-invitation-expiry-email": {
     "schedule_expression": "cron(0 7 * * ? *)"
+  },
+  "jl-invitation-deletion": {
+    "schedule_expression": "cron(0 1 * * ? *)"
   }
 }

--- a/terraform/nft/scheduled_tasks.json
+++ b/terraform/nft/scheduled_tasks.json
@@ -10,5 +10,8 @@
   },
   "jl-invitation-expiry-email": {
     "schedule_expression": "cron(0 7 * * ? *)"
+  },
+  "jl-invitation-deletion": {
+    "schedule_expression": "cron(0 1 * * ? *)"
   }
 }

--- a/terraform/production/scheduled_tasks.json
+++ b/terraform/production/scheduled_tasks.json
@@ -10,5 +10,8 @@
   },
   "jl-invitation-expiry-email": {
     "schedule_expression": "cron(0 7 * * ? *)"
+  },
+  "jl-invitation-deletion": {
+    "schedule_expression": "cron(0 1 * * ? *)"
   }
 }

--- a/terraform/test/scheduled_tasks.json
+++ b/terraform/test/scheduled_tasks.json
@@ -10,5 +10,8 @@
   },
   "jl-invitation-expiry-email": {
     "schedule_expression": "cron(0 7 * * ? *)"
+  },
+  "jl-invitation-deletion": {
+    "schedule_expression": "cron(0 1 * * ? *)"
   }
 }


### PR DESCRIPTION
## Ticket number

PDJB-269

## Goal of change

Adds JL invite deletion to the scheduled jobs

## Description of main change(s)

Adds the job to the tasks list

## Anything you'd like to highlight to the reviewer?

Have rebased onto Sammy's env fix, since his job didn't run without it, so mine wouldn't either.

## Checklist
Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Any special release instructions (e.g. set environment variables) have been added as checklist items to a draft PR (merging `main` into `test`) for the next release.
- [x] New scheduled tasks avoid 2-5am on wednesdays (SSM maintenance window).

  Make sure to include details such as the name of the variable, where it needs to be set (e.g. AWS Secrets Manager or Parameter Store), and what it should be set to (this might be a location in keeper where a secret value can be found)