### PR TITLE
PDJB-1035: Add PLAUSIBLE_API_KEY secret for Plausible analytics

### DIFF
--- a/terraform/environment_template/ecs_task_definition/data.tf.template
+++ b/terraform/environment_template/ecs_task_definition/data.tf.template
@@ -70,6 +70,10 @@ data "aws_secretsmanager_secret" "os_api_key" {
   name = "tf-${local.environment_name}-os-api-key"
 }
 
+data "aws_secretsmanager_secret" "plausible_api_key" {
+  name = "tf-${local.environment_name}-prsdb-plausible-api-key"
+}
+
 data "aws_ssm_parameter" "quarantine_bucket" {
   count = var.file_upload_buckets_created ? 1 : 0
   name = "${local.environment_name}-prsdb-quarantine-bucket"

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -169,6 +169,10 @@ locals {
       name      = "INTERNAL_ACCESS_CLIENT_SECRET"
       valueFrom = data.aws_secretsmanager_secret.internal_access_client_secret.arn
     },
+    {
+      name      = "PLAUSIBLE_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.plausible_api_key.arn
+    },
   ]
 }
 

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -70,6 +70,10 @@ data "aws_secretsmanager_secret" "os_api_key" {
   name = "tf-${local.environment_name}-os-api-key"
 }
 
+data "aws_secretsmanager_secret" "plausible_api_key" {
+  name = "tf-${local.environment_name}-prsdb-plausible-api-key"
+}
+
 data "aws_ssm_parameter" "quarantine_bucket" {
   count = var.file_upload_buckets_created ? 1 : 0
   name  = "${local.environment_name}-prsdb-quarantine-bucket"

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -169,6 +169,10 @@ locals {
       name      = "INTERNAL_ACCESS_CLIENT_SECRET"
       valueFrom = data.aws_secretsmanager_secret.internal_access_client_secret.arn
     },
+    {
+      name      = "PLAUSIBLE_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.plausible_api_key.arn
+    },
   ]
 }
 

--- a/terraform/modules/secrets/iam.tf
+++ b/terraform/modules/secrets/iam.tf
@@ -48,6 +48,7 @@ resource "aws_iam_role_policy" "secret_access" {
           aws_secretsmanager_secret.one_login_private_key.arn,
           aws_secretsmanager_secret.notify_api_key.arn,
           aws_secretsmanager_secret.os_api_key.arn,
+          aws_secretsmanager_secret.plausible_api_key.arn,
           aws_secretsmanager_secret.epc_register_client_secret.arn,
           aws_secretsmanager_secret.internal_access_client_secret.arn,
         ]

--- a/terraform/modules/secrets/secrets.tf
+++ b/terraform/modules/secrets/secrets.tf
@@ -53,6 +53,13 @@ resource "aws_secretsmanager_secret" "os_api_key" {
   kms_key_id              = aws_kms_key.prsdb_webapp_secrets.arn
 }
 
+resource "aws_secretsmanager_secret" "plausible_api_key" {
+  name                    = "tf-${var.environment_name}-prsdb-plausible-api-key"
+  description             = "API key for Plausible analytics"
+  recovery_window_in_days = 0
+  kms_key_id              = aws_kms_key.prsdb_webapp_secrets.arn
+}
+
 resource "aws_secretsmanager_secret" "epc_register_client_secret" {
   name                    = "tf-${var.environment_name}-prsdb-epc-client-secret"
   description             = "Client secret for the EPC register client secret"

--- a/terraform/nft/ecs_task_definition/data.tf
+++ b/terraform/nft/ecs_task_definition/data.tf
@@ -70,6 +70,10 @@ data "aws_secretsmanager_secret" "os_api_key" {
   name = "tf-${local.environment_name}-os-api-key"
 }
 
+data "aws_secretsmanager_secret" "plausible_api_key" {
+  name = "tf-${local.environment_name}-prsdb-plausible-api-key"
+}
+
 data "aws_ssm_parameter" "quarantine_bucket" {
   count = var.file_upload_buckets_created ? 1 : 0
   name  = "${local.environment_name}-prsdb-quarantine-bucket"

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -169,6 +169,10 @@ locals {
       name      = "INTERNAL_ACCESS_CLIENT_SECRET"
       valueFrom = data.aws_secretsmanager_secret.internal_access_client_secret.arn
     },
+    {
+      name      = "PLAUSIBLE_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.plausible_api_key.arn
+    },
   ]
 }
 

--- a/terraform/production/ecs_task_definition/data.tf
+++ b/terraform/production/ecs_task_definition/data.tf
@@ -70,6 +70,10 @@ data "aws_secretsmanager_secret" "os_api_key" {
   name = "tf-${local.environment_name}-os-api-key"
 }
 
+data "aws_secretsmanager_secret" "plausible_api_key" {
+  name = "tf-${local.environment_name}-prsdb-plausible-api-key"
+}
+
 data "aws_ssm_parameter" "quarantine_bucket" {
   count = var.file_upload_buckets_created ? 1 : 0
   name  = "${local.environment_name}-prsdb-quarantine-bucket"

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -169,6 +169,10 @@ locals {
       name      = "INTERNAL_ACCESS_CLIENT_SECRET"
       valueFrom = data.aws_secretsmanager_secret.internal_access_client_secret.arn
     },
+    {
+      name      = "PLAUSIBLE_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.plausible_api_key.arn
+    },
   ]
 }
 

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -70,6 +70,10 @@ data "aws_secretsmanager_secret" "os_api_key" {
   name = "tf-${local.environment_name}-os-api-key"
 }
 
+data "aws_secretsmanager_secret" "plausible_api_key" {
+  name = "tf-${local.environment_name}-prsdb-plausible-api-key"
+}
+
 data "aws_ssm_parameter" "quarantine_bucket" {
   count = var.file_upload_buckets_created ? 1 : 0
   name  = "${local.environment_name}-prsdb-quarantine-bucket"

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -169,6 +169,10 @@ locals {
       name      = "INTERNAL_ACCESS_CLIENT_SECRET"
       valueFrom = data.aws_secretsmanager_secret.internal_access_client_secret.arn
     },
+    {
+      name      = "PLAUSIBLE_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.plausible_api_key.arn
+    },
   ]
 }
 


### PR DESCRIPTION
## Ticket number

PDJB-1035

## Goal of change

Create the new `PLAUSIBLE_API_KEY` environment variable required by the Plausible analytics integration in [prsdb-webapp#1445](https://github.com/communitiesuk/prsdb-webapp/pull/1445), so deployments aren't broken when that PR merges.

## Description of main change(s)

- Adds a `plausible_api_key` Secrets Manager secret (`tf-<env>-prsdb-plausible-api-key`) in the shared secrets module, encrypted with the existing webapp secrets KMS key, and grants the webapp task execution role read access to it.
- Wires a `PLAUSIBLE_API_KEY` secret into the webapp ECS task definitions for all environments (integration, test, nft, production) and the environment template.
- `PLAUSIBLE_SITE_ID` already exists from earlier work; this PR adds the remaining API key secret.

## Anything you'd like to highlight to the reviewer?

- The secret is created empty by Terraform (no `secret_version`); the actual API key value must be set manually in AWS Secrets Manager per environment, matching how other API key secrets (e.g. `os-api-key`) are handled.
- Travis flagged on the webapp PR that this infra PR must be raised and merged before the webapp PR merges, otherwise integration deployments break.

## Checklist

- [x] Any special release instructions (e.g. set environment variables) have been added as checklist items to a draft PR (merging `main` into `test`) for the next release.

  **Action required:** Set the `PLAUSIBLE_API_KEY` value in AWS Secrets Manager (secret `tf-<env>-prsdb-plausible-api-key`) for each environment. The value is the Plausible Stats API key (see Keeper).