### PR TITLE
PDJB-1035 Add plausible-domain-id SSM parameter

### DIFF
--- a/terraform/environment_template/ecs_task_definition/data.tf.template
+++ b/terraform/environment_template/ecs_task_definition/data.tf.template
@@ -116,6 +116,10 @@ data "aws_ssm_parameter" "plausible_site_id" {
   name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
+data "aws_ssm_parameter" "plausible_domain_id" {
+  name = "${local.environment_name}-prsdb-plausible-domain-id"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -119,6 +119,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
+      name  = "PLAUSIBLE_DOMAIN_ID"
+      value = data.aws_ssm_parameter.plausible_domain_id.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -116,8 +116,8 @@ data "aws_ssm_parameter" "plausible_site_id" {
   name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
-data "aws_ssm_parameter" "plausible_script_id" {
-  name = "${local.environment_name}-prsdb-plausible-script-id"
+data "aws_ssm_parameter" "plausible_domain_id" {
+  name = "${local.environment_name}-prsdb-plausible-domain-id"
 }
 
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -116,6 +116,10 @@ data "aws_ssm_parameter" "plausible_site_id" {
   name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
+data "aws_ssm_parameter" "plausible_script_id" {
+  name = "${local.environment_name}-prsdb-plausible-script-id"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -119,8 +119,8 @@ locals {
       value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
-      name  = "PLAUSIBLE_SCRIPT_ID"
-      value = data.aws_ssm_parameter.plausible_script_id.value
+      name  = "PLAUSIBLE_DOMAIN_ID"
+      value = data.aws_ssm_parameter.plausible_domain_id.value
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -119,6 +119,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
+      name  = "PLAUSIBLE_SCRIPT_ID"
+      value = data.aws_ssm_parameter.plausible_script_id.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },

--- a/terraform/modules/ssm/parameters.tf
+++ b/terraform/modules/ssm/parameters.tf
@@ -122,6 +122,16 @@ resource "aws_ssm_parameter" "plausible_site_id" {
   }
 }
 
+resource "aws_ssm_parameter" "plausible_script_id" {
+  name  = "${var.environment_name}-prsdb-plausible-script-id"
+  type  = "String"
+  value = "default_to_be_set_manually" # To be set manually on AWS
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
 resource "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name  = "${var.environment_name}-prsdb-beta-feedback-team-email-address"
   type  = "String"

--- a/terraform/modules/ssm/parameters.tf
+++ b/terraform/modules/ssm/parameters.tf
@@ -122,8 +122,8 @@ resource "aws_ssm_parameter" "plausible_site_id" {
   }
 }
 
-resource "aws_ssm_parameter" "plausible_script_id" {
-  name  = "${var.environment_name}-prsdb-plausible-script-id"
+resource "aws_ssm_parameter" "plausible_domain_id" {
+  name  = "${var.environment_name}-prsdb-plausible-domain-id"
   type  = "String"
   value = "default_to_be_set_manually" # To be set manually on AWS
 

--- a/terraform/nft/ecs_task_definition/data.tf
+++ b/terraform/nft/ecs_task_definition/data.tf
@@ -116,8 +116,8 @@ data "aws_ssm_parameter" "plausible_site_id" {
   name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
-data "aws_ssm_parameter" "plausible_script_id" {
-  name = "${local.environment_name}-prsdb-plausible-script-id"
+data "aws_ssm_parameter" "plausible_domain_id" {
+  name = "${local.environment_name}-prsdb-plausible-domain-id"
 }
 
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {

--- a/terraform/nft/ecs_task_definition/data.tf
+++ b/terraform/nft/ecs_task_definition/data.tf
@@ -116,6 +116,10 @@ data "aws_ssm_parameter" "plausible_site_id" {
   name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
+data "aws_ssm_parameter" "plausible_script_id" {
+  name = "${local.environment_name}-prsdb-plausible-script-id"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -119,6 +119,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
+      name  = "PLAUSIBLE_SCRIPT_ID"
+      value = data.aws_ssm_parameter.plausible_script_id.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}"
     },

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -119,8 +119,8 @@ locals {
       value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
-      name  = "PLAUSIBLE_SCRIPT_ID"
-      value = data.aws_ssm_parameter.plausible_script_id.value
+      name  = "PLAUSIBLE_DOMAIN_ID"
+      value = data.aws_ssm_parameter.plausible_domain_id.value
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"

--- a/terraform/production/ecs_task_definition/data.tf
+++ b/terraform/production/ecs_task_definition/data.tf
@@ -116,8 +116,8 @@ data "aws_ssm_parameter" "plausible_site_id" {
   name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
-data "aws_ssm_parameter" "plausible_script_id" {
-  name = "${local.environment_name}-prsdb-plausible-script-id"
+data "aws_ssm_parameter" "plausible_domain_id" {
+  name = "${local.environment_name}-prsdb-plausible-domain-id"
 }
 
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {

--- a/terraform/production/ecs_task_definition/data.tf
+++ b/terraform/production/ecs_task_definition/data.tf
@@ -116,6 +116,10 @@ data "aws_ssm_parameter" "plausible_site_id" {
   name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
+data "aws_ssm_parameter" "plausible_script_id" {
+  name = "${local.environment_name}-prsdb-plausible-script-id"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -119,8 +119,8 @@ locals {
       value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
-      name  = "PLAUSIBLE_SCRIPT_ID"
-      value = data.aws_ssm_parameter.plausible_script_id.value
+      name  = "PLAUSIBLE_DOMAIN_ID"
+      value = data.aws_ssm_parameter.plausible_domain_id.value
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -119,6 +119,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
+      name  = "PLAUSIBLE_SCRIPT_ID"
+      value = data.aws_ssm_parameter.plausible_script_id.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -116,8 +116,8 @@ data "aws_ssm_parameter" "plausible_site_id" {
   name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
-data "aws_ssm_parameter" "plausible_script_id" {
-  name = "${local.environment_name}-prsdb-plausible-script-id"
+data "aws_ssm_parameter" "plausible_domain_id" {
+  name = "${local.environment_name}-prsdb-plausible-domain-id"
 }
 
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -116,6 +116,10 @@ data "aws_ssm_parameter" "plausible_site_id" {
   name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
+data "aws_ssm_parameter" "plausible_script_id" {
+  name = "${local.environment_name}-prsdb-plausible-script-id"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -119,8 +119,8 @@ locals {
       value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
-      name  = "PLAUSIBLE_SCRIPT_ID"
-      value = data.aws_ssm_parameter.plausible_script_id.value
+      name  = "PLAUSIBLE_DOMAIN_ID"
+      value = data.aws_ssm_parameter.plausible_domain_id.value
     },
     {
       name  = "SPRING_PROFILES_ACTIVE"

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -119,6 +119,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
+      name  = "PLAUSIBLE_SCRIPT_ID"
+      value = data.aws_ssm_parameter.plausible_script_id.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },


### PR DESCRIPTION
## Ticket number

PDJB-1035

## Goal of change

Add a new `plausible-domain-id` SSM parameter so the webapp can pass the Plausible site domain to the Stats API separately from the `pa-` snippet id.

## Description of main change(s)

- Adds a new `\-prsdb-plausible-domain-id` SSM Parameter Store parameter (plain `String`, placeholder value, set manually in AWS).
- Wires it into the integration, test, nft, production and environment_template ECS task definitions as the `PLAUSIBLE_DOMAIN_ID` env var.

`PLAUSIBLE_SITE_ID` is unchanged (it carries the `pa-` snippet id).

## Anything you'd like to highlight to the reviewer?

The parameter values are plain SSM config (not secrets) and are set manually in AWS. Release instructions for setting them will be tracked on the release PR / ticket rather than here.
