### PR TITLE
PDJB-1034: Add CloudWatch metric read env vars and GetMetricStatistics permission to webapp task

### DIFF
--- a/terraform/environment_template/ecs_task_definition/data.tf.template
+++ b/terraform/environment_template/ecs_task_definition/data.tf.template
@@ -42,6 +42,23 @@ data "aws_ssm_parameter" "redis_port" {
   name = "${local.environment_name}-prsdb-redis-port"
 }
 
+# CloudWatch metric dimension identifiers read by the System Operator dashboard.
+data "aws_ssm_parameter" "ecs_cluster_name" {
+  name = "${local.environment_name}-prsdb-ecs-cluster-name"
+}
+
+data "aws_ssm_parameter" "ecs_service_name" {
+  name = "${local.environment_name}-prsdb-ecs-service-name"
+}
+
+data "aws_ssm_parameter" "redis_cluster_id" {
+  name = "${local.environment_name}-prsdb-redis-cluster-id"
+}
+
+data "aws_ssm_parameter" "cloudfront_distribution_id" {
+  name = "${local.environment_name}-prsdb-cloudfront-distribution-id"
+}
+
 data "aws_secretsmanager_secret" "redis_password" {
   name = "tf-${local.environment_name}-prsdb-redis-password"
 }

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -64,6 +64,22 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "CLOUDWATCH_ECS_CLUSTER_NAME"
+      value = data.aws_ssm_parameter.ecs_cluster_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ECS_SERVICE_NAME"
+      value = data.aws_ssm_parameter.ecs_service_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ELASTICACHE_CLUSTER_ID"
+      value = data.aws_ssm_parameter.redis_cluster_id.value
+    },
+    {
+      name  = "CLOUDFRONT_DISTRIBUTION_ID"
+      value = data.aws_ssm_parameter.cloudfront_distribution_id.value
+    },
   ]
   webapp_only_environment_variables = [
     {

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -42,6 +42,23 @@ data "aws_ssm_parameter" "redis_port" {
   name = "${local.environment_name}-prsdb-redis-port"
 }
 
+# CloudWatch metric dimension identifiers read by the System Operator dashboard.
+data "aws_ssm_parameter" "ecs_cluster_name" {
+  name = "${local.environment_name}-prsdb-ecs-cluster-name"
+}
+
+data "aws_ssm_parameter" "ecs_service_name" {
+  name = "${local.environment_name}-prsdb-ecs-service-name"
+}
+
+data "aws_ssm_parameter" "redis_cluster_id" {
+  name = "${local.environment_name}-prsdb-redis-cluster-id"
+}
+
+data "aws_ssm_parameter" "cloudfront_distribution_id" {
+  name = "${local.environment_name}-prsdb-cloudfront-distribution-id"
+}
+
 data "aws_secretsmanager_secret" "redis_password" {
   name = "tf-${local.environment_name}-prsdb-redis-password"
 }

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -64,6 +64,22 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "CLOUDWATCH_ECS_CLUSTER_NAME"
+      value = data.aws_ssm_parameter.ecs_cluster_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ECS_SERVICE_NAME"
+      value = data.aws_ssm_parameter.ecs_service_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ELASTICACHE_CLUSTER_ID"
+      value = data.aws_ssm_parameter.redis_cluster_id.value
+    },
+    {
+      name  = "CLOUDFRONT_DISTRIBUTION_ID"
+      value = data.aws_ssm_parameter.cloudfront_distribution_id.value
+    },
   ]
   webapp_only_environment_variables = [
     {

--- a/terraform/modules/ecs_service/parameters.tf
+++ b/terraform/modules/ecs_service/parameters.tf
@@ -1,0 +1,13 @@
+# Published for the webapp ECS task definition (separate Terraform state) to read,
+# so the System Operator dashboard can query ECS metrics from CloudWatch.
+resource "aws_ssm_parameter" "ecs_cluster_name" {
+  name  = "${var.environment_name}-prsdb-ecs-cluster-name"
+  type  = "String"
+  value = aws_ecs_cluster.main.name
+}
+
+resource "aws_ssm_parameter" "ecs_service_name" {
+  name  = "${var.environment_name}-prsdb-ecs-service-name"
+  type  = "String"
+  value = aws_ecs_service.webapp.name
+}

--- a/terraform/modules/elasticache/parameters.tf
+++ b/terraform/modules/elasticache/parameters.tf
@@ -9,3 +9,12 @@ resource "aws_ssm_parameter" "redis_port" {
   type  = "String"
   value = var.redis_port
 }
+
+# Published for the webapp ECS task definition (separate Terraform state) to read,
+# so the System Operator dashboard can query ElastiCache metrics from CloudWatch.
+# CloudWatch uses the per-node CacheClusterId dimension, so we expose a member node id.
+resource "aws_ssm_parameter" "redis_cluster_id" {
+  name  = "${var.environment_name}-prsdb-redis-cluster-id"
+  type  = "String"
+  value = sort(tolist(aws_elasticache_replication_group.main.member_clusters))[0]
+}

--- a/terraform/modules/frontdoor/parameters.tf
+++ b/terraform/modules/frontdoor/parameters.tf
@@ -1,0 +1,7 @@
+# Published for the webapp ECS task definition (separate Terraform state) to read,
+# so the System Operator dashboard can query CloudFront metrics from CloudWatch.
+resource "aws_ssm_parameter" "cloudfront_distribution_id" {
+  name  = "${var.environment_name}-prsdb-cloudfront-distribution-id"
+  type  = "String"
+  value = aws_cloudfront_distribution.main.id
+}

--- a/terraform/modules/monitoring/webapp_metrics_publishing.tf
+++ b/terraform/modules/monitoring/webapp_metrics_publishing.tf
@@ -1,11 +1,13 @@
 # Allows the webapp ECS task role to publish JVM/process metrics to CloudWatch
-# via Micrometer's CloudWatch registry.
-# cloudwatch:PutMetricData does not support resource-level permissions, so a wildcard is required.
+# via Micrometer's CloudWatch registry, and to read infrastructure metrics back via
+# GetMetricStatistics to power the System Operator dashboard.
+# Neither cloudwatch:PutMetricData nor cloudwatch:GetMetricStatistics supports
+# resource-level permissions, so a wildcard is required.
 # See https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatch.html
 # tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "webapp_publish_cloudwatch_metrics" {
   statement {
-    actions   = ["cloudwatch:PutMetricData"]
+    actions   = ["cloudwatch:PutMetricData", "cloudwatch:GetMetricStatistics"]
     resources = ["*"]
     effect    = "Allow"
   }

--- a/terraform/nft/ecs_task_definition/data.tf
+++ b/terraform/nft/ecs_task_definition/data.tf
@@ -42,6 +42,23 @@ data "aws_ssm_parameter" "redis_port" {
   name = "${local.environment_name}-prsdb-redis-port"
 }
 
+# CloudWatch metric dimension identifiers read by the System Operator dashboard.
+data "aws_ssm_parameter" "ecs_cluster_name" {
+  name = "${local.environment_name}-prsdb-ecs-cluster-name"
+}
+
+data "aws_ssm_parameter" "ecs_service_name" {
+  name = "${local.environment_name}-prsdb-ecs-service-name"
+}
+
+data "aws_ssm_parameter" "redis_cluster_id" {
+  name = "${local.environment_name}-prsdb-redis-cluster-id"
+}
+
+data "aws_ssm_parameter" "cloudfront_distribution_id" {
+  name = "${local.environment_name}-prsdb-cloudfront-distribution-id"
+}
+
 data "aws_secretsmanager_secret" "redis_password" {
   name = "tf-${local.environment_name}-prsdb-redis-password"
 }

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -64,6 +64,22 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "CLOUDWATCH_ECS_CLUSTER_NAME"
+      value = data.aws_ssm_parameter.ecs_cluster_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ECS_SERVICE_NAME"
+      value = data.aws_ssm_parameter.ecs_service_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ELASTICACHE_CLUSTER_ID"
+      value = data.aws_ssm_parameter.redis_cluster_id.value
+    },
+    {
+      name  = "CLOUDFRONT_DISTRIBUTION_ID"
+      value = data.aws_ssm_parameter.cloudfront_distribution_id.value
+    },
   ]
   webapp_only_environment_variables = [
     {

--- a/terraform/production/ecs_task_definition/data.tf
+++ b/terraform/production/ecs_task_definition/data.tf
@@ -42,6 +42,23 @@ data "aws_ssm_parameter" "redis_port" {
   name = "${local.environment_name}-prsdb-redis-port"
 }
 
+# CloudWatch metric dimension identifiers read by the System Operator dashboard.
+data "aws_ssm_parameter" "ecs_cluster_name" {
+  name = "${local.environment_name}-prsdb-ecs-cluster-name"
+}
+
+data "aws_ssm_parameter" "ecs_service_name" {
+  name = "${local.environment_name}-prsdb-ecs-service-name"
+}
+
+data "aws_ssm_parameter" "redis_cluster_id" {
+  name = "${local.environment_name}-prsdb-redis-cluster-id"
+}
+
+data "aws_ssm_parameter" "cloudfront_distribution_id" {
+  name = "${local.environment_name}-prsdb-cloudfront-distribution-id"
+}
+
 data "aws_secretsmanager_secret" "redis_password" {
   name = "tf-${local.environment_name}-prsdb-redis-password"
 }

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -64,6 +64,22 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "CLOUDWATCH_ECS_CLUSTER_NAME"
+      value = data.aws_ssm_parameter.ecs_cluster_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ECS_SERVICE_NAME"
+      value = data.aws_ssm_parameter.ecs_service_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ELASTICACHE_CLUSTER_ID"
+      value = data.aws_ssm_parameter.redis_cluster_id.value
+    },
+    {
+      name  = "CLOUDFRONT_DISTRIBUTION_ID"
+      value = data.aws_ssm_parameter.cloudfront_distribution_id.value
+    },
   ]
   webapp_only_environment_variables = [
     {

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -42,6 +42,23 @@ data "aws_ssm_parameter" "redis_port" {
   name = "${local.environment_name}-prsdb-redis-port"
 }
 
+# CloudWatch metric dimension identifiers read by the System Operator dashboard.
+data "aws_ssm_parameter" "ecs_cluster_name" {
+  name = "${local.environment_name}-prsdb-ecs-cluster-name"
+}
+
+data "aws_ssm_parameter" "ecs_service_name" {
+  name = "${local.environment_name}-prsdb-ecs-service-name"
+}
+
+data "aws_ssm_parameter" "redis_cluster_id" {
+  name = "${local.environment_name}-prsdb-redis-cluster-id"
+}
+
+data "aws_ssm_parameter" "cloudfront_distribution_id" {
+  name = "${local.environment_name}-prsdb-cloudfront-distribution-id"
+}
+
 data "aws_secretsmanager_secret" "redis_password" {
   name = "tf-${local.environment_name}-prsdb-redis-password"
 }

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -64,6 +64,22 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "CLOUDWATCH_ECS_CLUSTER_NAME"
+      value = data.aws_ssm_parameter.ecs_cluster_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ECS_SERVICE_NAME"
+      value = data.aws_ssm_parameter.ecs_service_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ELASTICACHE_CLUSTER_ID"
+      value = data.aws_ssm_parameter.redis_cluster_id.value
+    },
+    {
+      name  = "CLOUDFRONT_DISTRIBUTION_ID"
+      value = data.aws_ssm_parameter.cloudfront_distribution_id.value
+    },
   ]
   webapp_only_environment_variables = [
     {


### PR DESCRIPTION
## Ticket number

PDJB-1034

## Goal of change

Enable the System Operator dashboard to read infrastructure metrics from CloudWatch in deployed environments. This is the **infra counterpart** to webapp PR [communitiesuk/prsdb-webapp#1486](https://github.com/communitiesuk/prsdb-webapp/pull/1486).

## Description of main change(s)

- **Four new env vars on the webapp ECS task** (added alongside `METRICS_CLOUDWATCH_NAMESPACE` in every environment's task definition, plus the `environment_template`): `CLOUDWATCH_ECS_CLUSTER_NAME`, `CLOUDWATCH_ECS_SERVICE_NAME`, `CLOUDWATCH_ELASTICACHE_CLUSTER_ID`, `CLOUDFRONT_DISTRIBUTION_ID`. These tell the webapp which resources to query via `GetMetricStatistics`.
- Values are not hardcoded. They are published as SSM parameters from the resource-owning modules (mirroring the existing `redis_url`/`redis_port` cross-state pattern) and read back via `data.aws_ssm_parameter` in the `ecs_task_definition` state:
  - `ecs_service` module → `*-prsdb-ecs-cluster-name`, `*-prsdb-ecs-service-name`
  - `elasticache` module → `*-prsdb-redis-cluster-id` (a member node id, matching CloudWatch's `CacheClusterId` dimension)
  - `frontdoor` module → `*-prsdb-cloudfront-distribution-id`
- **IAM:** the webapp task role's existing `cloudwatch:PutMetricData` statement now also grants `cloudwatch:GetMetricStatistics` (shared `modules/monitoring` module, so all environments are covered). `GetMetricStatistics` has no resource-level permissions, so the existing `resources = ["*"]` wildcard and `tfsec:ignore` comment still apply; the surrounding comment was updated to mention the read use.

## Anything you'd like to highlight to the reviewer?

- This is the infra counterpart to webapp PR communitiesuk/prsdb-webapp#1486.
- **Safe to apply before or after the webapp deploy:** the webapp defaults these dimension identifiers to empty and renders "No data" until both the env vars and the IAM permission are live, so the dashboard degrades gracefully and there is no ordering requirement between the two deploys.
- `METRICS_CLOUDWATCH_NAMESPACE` (Micrometer metric *publishing*) is unrelated and was left untouched.
- Verification: relied on CI (`terraform fmt`/`validate`/`tflint`/`tfsec`) as Terraform is not installed locally; `terraform apply` was not run.

## Checklist

- [x] Any special release instructions (e.g. set environment variables) have been added as checklist items to a draft PR (merging `main` into `test`) for the next release.

  The four new env vars and the `GetMetricStatistics` IAM permission are wired entirely in Terraform from existing resource attributes/SSM parameters — no manual variable or secret setup is required.
