### PR TITLE
PDJB-NONE: Run task-def refresh after main infra apply to avoid SSM parameter race

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -36,7 +36,13 @@ jobs:
 
   refresh-task-definitions:
     name: Refresh task definitions
-    needs: validate-target-environment
+    # Wait for the main infra apply so any SSM parameters the ecs_task_definition
+    # state reads (e.g. CloudWatch metric dimension ids) already exist, avoiding a
+    # race where the task-def plan reads a parameter before apply creates it.
+    # The apply job is skipped when the main infra has no changes, so proceed as
+    # long as nothing it depends on failed or was cancelled.
+    needs: [validate-target-environment, apply]
+    if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/refresh-task-definitions.yml
     with:
       environment: ${{ inputs.environment }}

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -41,7 +41,7 @@ jobs:
     # race where the task-def plan reads a parameter before apply creates it.
     # The apply job is skipped when the main infra has no changes, so proceed as
     # long as nothing it depends on failed or was cancelled.
-    needs: [validate-target-environment, apply]
+    needs: apply
     if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/refresh-task-definitions.yml
     with:


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Prevent the ECS task-definition refresh from racing ahead of the main infra apply, which can leave it reading SSM parameters that the apply has not created yet.

## Description of main change(s)

In the `apply` workflow, the `refresh-task-definitions` job previously ran in parallel with the main Terraform `plan`/`apply` (both only depended on `validate-target-environment`). The `ecs_task_definition` state reads several SSM parameters (e.g. the CloudWatch metric dimension ids) that are *created* by the main infra apply. On the first apply that introduces a new such parameter, the refresh could start before the apply created it and fail with `reading SSM Parameter (...): couldn't find resource`.

This change makes `refresh-task-definitions` wait for the main infra `apply` to finish first, so any parameters it reads already exist.

## Anything you'd like to highlight to the reviewer?

- This was triggered for real on the NFT deploy of PDJB-1034: the task-def plan read the new `*-prsdb-ecs-cluster-name` / `*-prsdb-redis-cluster-id` / `*-prsdb-cloudfront-distribution-id` parameters ~74s before the main apply created them.
- The main `apply` job is **skipped** when the main infra has no changes (`if: needs.plan.outputs.plan-exit-code == 2`). To avoid `refresh-task-definitions` being skipped along with it (which would break every deploy where infra is unchanged), it uses `if: ${{ !failure() && !cancelled() }}` so it runs on a successful *or* skipped apply, and only halts if a dependency actually failed or was cancelled.
- Note this only affects the push-triggered `apply.yml` path. The manual `deploy.yml` path does not run the main apply at all and still assumes the parameters already exist from a prior apply.

## Checklist

- No special release instructions and no environment variables to set — this is a CI workflow ordering change only.
