### PR TITLE
PDJB-1034: Add PLAUSIBLE_TRANSACTION_EVENT_START_DATE env var per environment

### DIFF
--- a/terraform/environment_template/ecs_task_definition/data.tf.template
+++ b/terraform/environment_template/ecs_task_definition/data.tf.template
@@ -137,6 +137,10 @@ data "aws_ssm_parameter" "plausible_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-domain-id"
 }
 
+data "aws_ssm_parameter" "plausible_transaction_event_start_date" {
+  name = "${local.environment_name}-prsdb-plausible-transaction-event-start-date"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -139,6 +139,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_domain_id.value
     },
     {
+      name  = "PLAUSIBLE_TRANSACTION_EVENT_START_DATE"
+      value = data.aws_ssm_parameter.plausible_transaction_event_start_date.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -137,6 +137,10 @@ data "aws_ssm_parameter" "plausible_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-domain-id"
 }
 
+data "aws_ssm_parameter" "plausible_transaction_event_start_date" {
+  name = "${local.environment_name}-prsdb-plausible-transaction-event-start-date"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -139,6 +139,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_domain_id.value
     },
     {
+      name  = "PLAUSIBLE_TRANSACTION_EVENT_START_DATE"
+      value = data.aws_ssm_parameter.plausible_transaction_event_start_date.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },

--- a/terraform/modules/ssm/parameters.tf
+++ b/terraform/modules/ssm/parameters.tf
@@ -132,6 +132,16 @@ resource "aws_ssm_parameter" "plausible_domain_id" {
   }
 }
 
+resource "aws_ssm_parameter" "plausible_transaction_event_start_date" {
+  name  = "${var.environment_name}-prsdb-plausible-transaction-event-start-date"
+  type  = "String"
+  value = "2099-01-01" # Far-future default keeps the metric on the legacy method; set the real go-live date manually on AWS
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
 resource "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name  = "${var.environment_name}-prsdb-beta-feedback-team-email-address"
   type  = "String"

--- a/terraform/nft/ecs_task_definition/data.tf
+++ b/terraform/nft/ecs_task_definition/data.tf
@@ -137,6 +137,10 @@ data "aws_ssm_parameter" "plausible_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-domain-id"
 }
 
+data "aws_ssm_parameter" "plausible_transaction_event_start_date" {
+  name = "${local.environment_name}-prsdb-plausible-transaction-event-start-date"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -139,6 +139,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_domain_id.value
     },
     {
+      name  = "PLAUSIBLE_TRANSACTION_EVENT_START_DATE"
+      value = data.aws_ssm_parameter.plausible_transaction_event_start_date.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}"
     },

--- a/terraform/production/ecs_task_definition/data.tf
+++ b/terraform/production/ecs_task_definition/data.tf
@@ -137,6 +137,10 @@ data "aws_ssm_parameter" "plausible_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-domain-id"
 }
 
+data "aws_ssm_parameter" "plausible_transaction_event_start_date" {
+  name = "${local.environment_name}-prsdb-plausible-transaction-event-start-date"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -139,6 +139,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_domain_id.value
     },
     {
+      name  = "PLAUSIBLE_TRANSACTION_EVENT_START_DATE"
+      value = data.aws_ssm_parameter.plausible_transaction_event_start_date.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -137,6 +137,10 @@ data "aws_ssm_parameter" "plausible_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-domain-id"
 }
 
+data "aws_ssm_parameter" "plausible_transaction_event_start_date" {
+  name = "${local.environment_name}-prsdb-plausible-transaction-event-start-date"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -139,6 +139,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_domain_id.value
     },
     {
+      name  = "PLAUSIBLE_TRANSACTION_EVENT_START_DATE"
+      value = data.aws_ssm_parameter.plausible_transaction_event_start_date.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },


### PR DESCRIPTION
## What this does

Adds the `PLAUSIBLE_TRANSACTION_EVENT_START_DATE` environment variable to the webapp service in every environment, wired through the same mechanism as the existing `PLAUSIBLE_SITE_ID` / `PLAUSIBLE_DOMAIN_ID` non-secret vars (SSM parameter -> `data.aws_ssm_parameter` -> ECS task definition env var).

## Cutover behaviour

The prsdb-webapp (communitiesuk/prsdb-webapp#1516, PDJB-1034) added a Plausible `Transaction` custom event. The system-operator metrics dashboard "Total number of transactions" row counts these events, but only for reporting periods on/after this configured cutover date; before that date it falls back to the legacy Flow-event counting method.

`application.yml` consumes it as:

```
transaction-event-start-date: ${PLAUSIBLE_TRANSACTION_EVENT_START_DATE:2099-01-01}
```

The app default (`2099-01-01`, far-future) deliberately keeps the metric on the legacy method until infra sets a real date. That default stays in the app repo and is unchanged here.

## Value per environment

Following the same placeholder-set-manually pattern as `SITE_ID` / `DOMAIN_ID`, the SSM parameter is created by Terraform with a **far-future placeholder of `2099-01-01`** and `lifecycle { ignore_changes = [value] }`. The real go-live date is then set **manually on AWS SSM** per environment, without being reverted by Terraform.

| Environment | Terraform value | AWS SSM (set manually) |
|---|---|---|
| integration | `2099-01-01` (placeholder) | real go-live date |
| test | `2099-01-01` (placeholder) | real go-live date |
| nft | `2099-01-01` (placeholder) | real go-live date |
| production | `2099-01-01` (placeholder) | real go-live date |
| environment_template | `2099-01-01` (placeholder) | n/a (scaffold) |

Using `2099-01-01` (a valid ISO date) as the placeholder — rather than the `default_to_be_set_manually` string used for SITE_ID/DOMAIN_ID — ensures the value always parses and safely keeps the metric on the legacy method until a real date is set.

## Files changed

- `terraform/modules/ssm/parameters.tf` - new `aws_ssm_parameter.plausible_transaction_event_start_date`
- `terraform/{integration,test,nft,production}/ecs_task_definition/{data.tf,main.tf}` - data source + env var
- `terraform/environment_template/ecs_task_definition/{data.tf.template,main.tf.template}` - same, for new envs

## Related

- Webapp PR: communitiesuk/prsdb-webapp#1516
