### PR TITLE
Release test to production #12

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -36,7 +36,13 @@ jobs:
 
   refresh-task-definitions:
     name: Refresh task definitions
-    needs: validate-target-environment
+    # Wait for the main infra apply so any SSM parameters the ecs_task_definition
+    # state reads (e.g. CloudWatch metric dimension ids) already exist, avoiding a
+    # race where the task-def plan reads a parameter before apply creates it.
+    # The apply job is skipped when the main infra has no changes, so proceed as
+    # long as nothing it depends on failed or was cancelled.
+    needs: apply
+    if: ${{ !failure() && !cancelled() }}
     uses: ./.github/workflows/refresh-task-definitions.yml
     with:
       environment: ${{ inputs.environment }}

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -280,3 +280,13 @@ Where schedule expression is a cron or rate expression as defined in the [AWS do
 This will trigger a copy of the webapp container in line with the schedule. The container will have the Spring profiles set to `web-server-deactivated`, `scheduled-task`, `<environment>`, and `<name-of-task>-scheduled-task` which should be used to select the correct application runner in the webapp for this particular task in the correct environment.
 
 Our SSM maintenance window is 2-5am every Wednesday, so we should avoid scheduling tasks in that timeslot in case of disruption.
+
+### QA for scheduled tasks
+For QAing scheduled tasks (if you don’t want to wait for it to run!), it’s best to change when the event is triggered rather than just running the task (as then you are also testing that the triggering is working).
+
+* Go to AWS → Amazon EventBridge → Schedules (under “Scheduler” in the left hand side panel)
+* Select the schedule you are testing (e.g. `integration-jl-invitation-deletion-scheduled-task`) and click "Edit"
+* Note the value of the Cron expression, then change it to a few minutes away (remembering it’s on GMT not BST) and save the schedule.
+* Once the task has run, change the Cron expression back to the original value.
+
+Each scheduled task has a corresponding log group in CloudWatch which can be used for debugging as required.

--- a/terraform/environment_template/ecs_task_definition/data.tf.template
+++ b/terraform/environment_template/ecs_task_definition/data.tf.template
@@ -116,6 +116,10 @@ data "aws_ssm_parameter" "plausible_site_id" {
   name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
+data "aws_ssm_parameter" "plausible_domain_id" {
+  name = "${local.environment_name}-prsdb-plausible-domain-id"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/environment_template/ecs_task_definition/data.tf.template
+++ b/terraform/environment_template/ecs_task_definition/data.tf.template
@@ -42,6 +42,23 @@ data "aws_ssm_parameter" "redis_port" {
   name = "${local.environment_name}-prsdb-redis-port"
 }
 
+# CloudWatch metric dimension identifiers read by the System Operator dashboard.
+data "aws_ssm_parameter" "ecs_cluster_name" {
+  name = "${local.environment_name}-prsdb-ecs-cluster-name"
+}
+
+data "aws_ssm_parameter" "ecs_service_name" {
+  name = "${local.environment_name}-prsdb-ecs-service-name"
+}
+
+data "aws_ssm_parameter" "redis_cluster_id" {
+  name = "${local.environment_name}-prsdb-redis-cluster-id"
+}
+
+data "aws_ssm_parameter" "cloudfront_distribution_id" {
+  name = "${local.environment_name}-prsdb-cloudfront-distribution-id"
+}
+
 data "aws_secretsmanager_secret" "redis_password" {
   name = "tf-${local.environment_name}-prsdb-redis-password"
 }

--- a/terraform/environment_template/ecs_task_definition/data.tf.template
+++ b/terraform/environment_template/ecs_task_definition/data.tf.template
@@ -137,6 +137,10 @@ data "aws_ssm_parameter" "plausible_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-domain-id"
 }
 
+data "aws_ssm_parameter" "plausible_transaction_event_start_date" {
+  name = "${local.environment_name}-prsdb-plausible-transaction-event-start-date"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/environment_template/ecs_task_definition/data.tf.template
+++ b/terraform/environment_template/ecs_task_definition/data.tf.template
@@ -70,6 +70,10 @@ data "aws_secretsmanager_secret" "os_api_key" {
   name = "tf-${local.environment_name}-os-api-key"
 }
 
+data "aws_secretsmanager_secret" "plausible_api_key" {
+  name = "tf-${local.environment_name}-prsdb-plausible-api-key"
+}
+
 data "aws_ssm_parameter" "quarantine_bucket" {
   count = var.file_upload_buckets_created ? 1 : 0
   name = "${local.environment_name}-prsdb-quarantine-bucket"

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -169,6 +169,10 @@ locals {
       name      = "INTERNAL_ACCESS_CLIENT_SECRET"
       valueFrom = data.aws_secretsmanager_secret.internal_access_client_secret.arn
     },
+    {
+      name      = "PLAUSIBLE_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.plausible_api_key.arn
+    },
   ]
 }
 

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -64,6 +64,22 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "CLOUDWATCH_ECS_CLUSTER_NAME"
+      value = data.aws_ssm_parameter.ecs_cluster_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ECS_SERVICE_NAME"
+      value = data.aws_ssm_parameter.ecs_service_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ELASTICACHE_CLUSTER_ID"
+      value = data.aws_ssm_parameter.redis_cluster_id.value
+    },
+    {
+      name  = "CLOUDFRONT_DISTRIBUTION_ID"
+      value = data.aws_ssm_parameter.cloudfront_distribution_id.value
+    },
   ]
   webapp_only_environment_variables = [
     {

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -139,6 +139,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_domain_id.value
     },
     {
+      name  = "PLAUSIBLE_TRANSACTION_EVENT_START_DATE"
+      value = data.aws_ssm_parameter.plausible_transaction_event_start_date.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },

--- a/terraform/environment_template/ecs_task_definition/main.tf.template
+++ b/terraform/environment_template/ecs_task_definition/main.tf.template
@@ -119,6 +119,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
+      name  = "PLAUSIBLE_DOMAIN_ID"
+      value = data.aws_ssm_parameter.plausible_domain_id.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -116,6 +116,10 @@ data "aws_ssm_parameter" "plausible_site_id" {
   name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
+data "aws_ssm_parameter" "plausible_domain_id" {
+  name = "${local.environment_name}-prsdb-plausible-domain-id"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -42,6 +42,23 @@ data "aws_ssm_parameter" "redis_port" {
   name = "${local.environment_name}-prsdb-redis-port"
 }
 
+# CloudWatch metric dimension identifiers read by the System Operator dashboard.
+data "aws_ssm_parameter" "ecs_cluster_name" {
+  name = "${local.environment_name}-prsdb-ecs-cluster-name"
+}
+
+data "aws_ssm_parameter" "ecs_service_name" {
+  name = "${local.environment_name}-prsdb-ecs-service-name"
+}
+
+data "aws_ssm_parameter" "redis_cluster_id" {
+  name = "${local.environment_name}-prsdb-redis-cluster-id"
+}
+
+data "aws_ssm_parameter" "cloudfront_distribution_id" {
+  name = "${local.environment_name}-prsdb-cloudfront-distribution-id"
+}
+
 data "aws_secretsmanager_secret" "redis_password" {
   name = "tf-${local.environment_name}-prsdb-redis-password"
 }

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -70,6 +70,10 @@ data "aws_secretsmanager_secret" "os_api_key" {
   name = "tf-${local.environment_name}-os-api-key"
 }
 
+data "aws_secretsmanager_secret" "plausible_api_key" {
+  name = "tf-${local.environment_name}-prsdb-plausible-api-key"
+}
+
 data "aws_ssm_parameter" "quarantine_bucket" {
   count = var.file_upload_buckets_created ? 1 : 0
   name  = "${local.environment_name}-prsdb-quarantine-bucket"

--- a/terraform/integration/ecs_task_definition/data.tf
+++ b/terraform/integration/ecs_task_definition/data.tf
@@ -137,6 +137,10 @@ data "aws_ssm_parameter" "plausible_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-domain-id"
 }
 
+data "aws_ssm_parameter" "plausible_transaction_event_start_date" {
+  name = "${local.environment_name}-prsdb-plausible-transaction-event-start-date"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -169,6 +169,10 @@ locals {
       name      = "INTERNAL_ACCESS_CLIENT_SECRET"
       valueFrom = data.aws_secretsmanager_secret.internal_access_client_secret.arn
     },
+    {
+      name      = "PLAUSIBLE_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.plausible_api_key.arn
+    },
   ]
 }
 

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -64,6 +64,22 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "CLOUDWATCH_ECS_CLUSTER_NAME"
+      value = data.aws_ssm_parameter.ecs_cluster_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ECS_SERVICE_NAME"
+      value = data.aws_ssm_parameter.ecs_service_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ELASTICACHE_CLUSTER_ID"
+      value = data.aws_ssm_parameter.redis_cluster_id.value
+    },
+    {
+      name  = "CLOUDFRONT_DISTRIBUTION_ID"
+      value = data.aws_ssm_parameter.cloudfront_distribution_id.value
+    },
   ]
   webapp_only_environment_variables = [
     {

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -139,6 +139,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_domain_id.value
     },
     {
+      name  = "PLAUSIBLE_TRANSACTION_EVENT_START_DATE"
+      value = data.aws_ssm_parameter.plausible_transaction_event_start_date.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },

--- a/terraform/integration/ecs_task_definition/main.tf
+++ b/terraform/integration/ecs_task_definition/main.tf
@@ -119,6 +119,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
+      name  = "PLAUSIBLE_DOMAIN_ID"
+      value = data.aws_ssm_parameter.plausible_domain_id.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },

--- a/terraform/modules/ecs_service/parameters.tf
+++ b/terraform/modules/ecs_service/parameters.tf
@@ -1,0 +1,13 @@
+# Published for the webapp ECS task definition (separate Terraform state) to read,
+# so the System Operator dashboard can query ECS metrics from CloudWatch.
+resource "aws_ssm_parameter" "ecs_cluster_name" {
+  name  = "${var.environment_name}-prsdb-ecs-cluster-name"
+  type  = "String"
+  value = aws_ecs_cluster.main.name
+}
+
+resource "aws_ssm_parameter" "ecs_service_name" {
+  name  = "${var.environment_name}-prsdb-ecs-service-name"
+  type  = "String"
+  value = aws_ecs_service.webapp.name
+}

--- a/terraform/modules/elasticache/parameters.tf
+++ b/terraform/modules/elasticache/parameters.tf
@@ -9,3 +9,12 @@ resource "aws_ssm_parameter" "redis_port" {
   type  = "String"
   value = var.redis_port
 }
+
+# Published for the webapp ECS task definition (separate Terraform state) to read,
+# so the System Operator dashboard can query ElastiCache metrics from CloudWatch.
+# CloudWatch uses the per-node CacheClusterId dimension, so we expose a member node id.
+resource "aws_ssm_parameter" "redis_cluster_id" {
+  name  = "${var.environment_name}-prsdb-redis-cluster-id"
+  type  = "String"
+  value = sort(tolist(aws_elasticache_replication_group.main.member_clusters))[0]
+}

--- a/terraform/modules/frontdoor/cloudfront_waf.tf
+++ b/terraform/modules/frontdoor/cloudfront_waf.tf
@@ -132,6 +132,27 @@ resource "aws_wafv2_web_acl" "main" {
             count {}
           }
         }
+        rule_action_override {
+          # These body-inspection rules can give false positives on file uploads because they interpret the file
+          # data as matching patterns. https://repost.aws/knowledge-center/waf-upload-blocked-files
+          # We have a separate rule blocking requests that match to ensure only file-upload endpoints accept suspicious requests.
+          name = "GenericLFI_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+        rule_action_override {
+          name = "GenericRFI_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+        rule_action_override {
+          name = "EC2MetaDataSSRF_BODY"
+          action_to_use {
+            count {}
+          }
+        }
       }
     }
 
@@ -194,6 +215,22 @@ resource "aws_wafv2_web_acl" "main" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesKnownBadInputsRuleSet"
         vendor_name = "AWS"
+
+        rule_action_override {
+          # These body-inspection rules can give false positives on file uploads because they interpret the file
+          # data as matching patterns. https://repost.aws/knowledge-center/waf-upload-blocked-files
+          # We have a separate rule blocking requests that match to ensure only file-upload endpoints accept suspicious requests.
+          name = "JavaDeserializationRCE_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+        rule_action_override {
+          name = "Log4JRCE_BODY"
+          action_to_use {
+            count {}
+          }
+        }
       }
     }
 
@@ -226,6 +263,15 @@ resource "aws_wafv2_web_acl" "main" {
             count {}
           }
         }
+        rule_action_override {
+          # This body-inspection rule can give false positives on file uploads because it interprets the file
+          # data as matching patterns. https://repost.aws/knowledge-center/waf-upload-blocked-files
+          # We have a separate rule blocking requests that match to ensure only file-upload endpoints accept suspicious requests.
+          name = "SQLiExtendedPatterns_BODY"
+          action_to_use {
+            count {}
+          }
+        }
       }
     }
 
@@ -237,9 +283,44 @@ resource "aws_wafv2_web_acl" "main" {
   }
 
   rule {
-    name = "block-counted-rules-on-non-file-upload-requests"
-    # This rule must be applied after the rules containing AWSManagedRulesCommonRuleSet and AWSManagedRulesSQLiRuleSet
+    name = "aws-managed-rules-unix-rule-set"
+    # This group is applied before the block-counted-rules-on-non-file-upload-requests rule (priority 9) so that its
+    # body-inspection label is available to it.
     priority = 8
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesUnixRuleSet"
+        vendor_name = "AWS"
+
+        rule_action_override {
+          # This body-inspection rule can give false positives on file uploads because it interprets the file
+          # data as matching patterns. https://repost.aws/knowledge-center/waf-upload-blocked-files
+          # We have a separate rule blocking requests that match to ensure only file-upload endpoints accept suspicious requests.
+          name = "UNIXShellCommandsVariables_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "waf-block-unix-exploit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name = "block-counted-rules-on-non-file-upload-requests"
+    # This rule must be applied after the managed rule groups whose body-inspection rules are overridden to count
+    # (AWSManagedRulesCommonRuleSet, AWSManagedRulesKnownBadInputsRuleSet, AWSManagedRulesSQLiRuleSet and AWSManagedRulesUnixRuleSet)
+    priority = 9
 
     action {
       block {}
@@ -264,6 +345,48 @@ resource "aws_wafv2_web_acl" "main" {
             statement {
               label_match_statement {
                 key   = "awswaf:managed:aws:sql-database:SQLi_Body"
+                scope = "LABEL"
+              }
+            }
+            statement {
+              label_match_statement {
+                key   = "awswaf:managed:aws:core-rule-set:GenericLFI_Body"
+                scope = "LABEL"
+              }
+            }
+            statement {
+              label_match_statement {
+                key   = "awswaf:managed:aws:core-rule-set:GenericRFI_Body"
+                scope = "LABEL"
+              }
+            }
+            statement {
+              label_match_statement {
+                key   = "awswaf:managed:aws:core-rule-set:EC2MetaDataSSRF_Body"
+                scope = "LABEL"
+              }
+            }
+            statement {
+              label_match_statement {
+                key   = "awswaf:managed:aws:known-bad-inputs:JavaDeserializationRCE_Body"
+                scope = "LABEL"
+              }
+            }
+            statement {
+              label_match_statement {
+                key   = "awswaf:managed:aws:known-bad-inputs:Log4JRCE_Body"
+                scope = "LABEL"
+              }
+            }
+            statement {
+              label_match_statement {
+                key   = "awswaf:managed:aws:sql-database:SQLiExtendedPatterns_Body"
+                scope = "LABEL"
+              }
+            }
+            statement {
+              label_match_statement {
+                key   = "awswaf:managed:aws:posix-os:UNIXShellCommandsVariables_Body"
                 scope = "LABEL"
               }
             }
@@ -299,7 +422,7 @@ resource "aws_wafv2_web_acl" "main" {
 
   rule {
     name     = "aws-managed-rules-linux-rule-set"
-    priority = 9
+    priority = 10
 
     override_action {
       none {}
@@ -315,28 +438,6 @@ resource "aws_wafv2_web_acl" "main" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "waf-block-linux-exploit"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  rule {
-    name     = "aws-managed-rules-unix-rule-set"
-    priority = 10
-
-    override_action {
-      none {}
-    }
-
-    statement {
-      managed_rule_group_statement {
-        name        = "AWSManagedRulesUnixRuleSet"
-        vendor_name = "AWS"
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "waf-block-unix-exploit"
       sampled_requests_enabled   = true
     }
   }

--- a/terraform/modules/frontdoor/load_balancer_waf.tf
+++ b/terraform/modules/frontdoor/load_balancer_waf.tf
@@ -105,6 +105,27 @@ resource "aws_wafv2_web_acl" "load_balancer" {
             count {}
           }
         }
+        rule_action_override {
+          # These body-inspection rules can give false positives on file uploads because they interpret the file
+          # data as matching patterns. https://repost.aws/knowledge-center/waf-upload-blocked-files
+          # We have a separate rule blocking requests that match to ensure only file-upload endpoints accept suspicious requests.
+          name = "GenericLFI_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+        rule_action_override {
+          name = "GenericRFI_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+        rule_action_override {
+          name = "EC2MetaDataSSRF_BODY"
+          action_to_use {
+            count {}
+          }
+        }
       }
     }
 
@@ -167,6 +188,22 @@ resource "aws_wafv2_web_acl" "load_balancer" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesKnownBadInputsRuleSet"
         vendor_name = "AWS"
+
+        rule_action_override {
+          # These body-inspection rules can give false positives on file uploads because they interpret the file
+          # data as matching patterns. https://repost.aws/knowledge-center/waf-upload-blocked-files
+          # We have a separate rule blocking requests that match to ensure only file-upload endpoints accept suspicious requests.
+          name = "JavaDeserializationRCE_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+        rule_action_override {
+          name = "Log4JRCE_BODY"
+          action_to_use {
+            count {}
+          }
+        }
       }
     }
 
@@ -199,6 +236,15 @@ resource "aws_wafv2_web_acl" "load_balancer" {
             count {}
           }
         }
+        rule_action_override {
+          # This body-inspection rule can give false positives on file uploads because it interprets the file
+          # data as matching patterns. https://repost.aws/knowledge-center/waf-upload-blocked-files
+          # We have a separate rule blocking requests that match to ensure only file-upload endpoints accept suspicious requests.
+          name = "SQLiExtendedPatterns_BODY"
+          action_to_use {
+            count {}
+          }
+        }
       }
     }
 
@@ -210,9 +256,44 @@ resource "aws_wafv2_web_acl" "load_balancer" {
   }
 
   rule {
-    name = "block-counted-rules-on-non-file-upload-requests"
-    # This rule must be applied after the rules containing AWSManagedRulesCommonRuleSet and AWSManagedRulesSQLiRuleSet
+    name = "aws-managed-rules-unix-rule-set"
+    # This group is applied before the block-counted-rules-on-non-file-upload-requests rule (priority 9) so that its
+    # body-inspection label is available to it.
     priority = 8
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesUnixRuleSet"
+        vendor_name = "AWS"
+
+        rule_action_override {
+          # This body-inspection rule can give false positives on file uploads because it interprets the file
+          # data as matching patterns. https://repost.aws/knowledge-center/waf-upload-blocked-files
+          # We have a separate rule blocking requests that match to ensure only file-upload endpoints accept suspicious requests.
+          name = "UNIXShellCommandsVariables_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "waf-block-unix-exploit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name = "block-counted-rules-on-non-file-upload-requests"
+    # This rule must be applied after the managed rule groups whose body-inspection rules are overridden to count
+    # (AWSManagedRulesCommonRuleSet, AWSManagedRulesKnownBadInputsRuleSet, AWSManagedRulesSQLiRuleSet and AWSManagedRulesUnixRuleSet)
+    priority = 9
 
     action {
       block {}
@@ -237,6 +318,48 @@ resource "aws_wafv2_web_acl" "load_balancer" {
             statement {
               label_match_statement {
                 key   = "awswaf:managed:aws:sql-database:SQLi_Body"
+                scope = "LABEL"
+              }
+            }
+            statement {
+              label_match_statement {
+                key   = "awswaf:managed:aws:core-rule-set:GenericLFI_Body"
+                scope = "LABEL"
+              }
+            }
+            statement {
+              label_match_statement {
+                key   = "awswaf:managed:aws:core-rule-set:GenericRFI_Body"
+                scope = "LABEL"
+              }
+            }
+            statement {
+              label_match_statement {
+                key   = "awswaf:managed:aws:core-rule-set:EC2MetaDataSSRF_Body"
+                scope = "LABEL"
+              }
+            }
+            statement {
+              label_match_statement {
+                key   = "awswaf:managed:aws:known-bad-inputs:JavaDeserializationRCE_Body"
+                scope = "LABEL"
+              }
+            }
+            statement {
+              label_match_statement {
+                key   = "awswaf:managed:aws:known-bad-inputs:Log4JRCE_Body"
+                scope = "LABEL"
+              }
+            }
+            statement {
+              label_match_statement {
+                key   = "awswaf:managed:aws:sql-database:SQLiExtendedPatterns_Body"
+                scope = "LABEL"
+              }
+            }
+            statement {
+              label_match_statement {
+                key   = "awswaf:managed:aws:posix-os:UNIXShellCommandsVariables_Body"
                 scope = "LABEL"
               }
             }
@@ -272,7 +395,7 @@ resource "aws_wafv2_web_acl" "load_balancer" {
 
   rule {
     name     = "aws-managed-rules-linux-rule-set"
-    priority = 9
+    priority = 10
 
     override_action {
       none {}
@@ -288,28 +411,6 @@ resource "aws_wafv2_web_acl" "load_balancer" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "waf-block-linux-exploit"
-      sampled_requests_enabled   = true
-    }
-  }
-
-  rule {
-    name     = "aws-managed-rules-unix-rule-set"
-    priority = 10
-
-    override_action {
-      none {}
-    }
-
-    statement {
-      managed_rule_group_statement {
-        name        = "AWSManagedRulesUnixRuleSet"
-        vendor_name = "AWS"
-      }
-    }
-
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "waf-block-unix-exploit"
       sampled_requests_enabled   = true
     }
   }

--- a/terraform/modules/frontdoor/parameters.tf
+++ b/terraform/modules/frontdoor/parameters.tf
@@ -1,0 +1,7 @@
+# Published for the webapp ECS task definition (separate Terraform state) to read,
+# so the System Operator dashboard can query CloudFront metrics from CloudWatch.
+resource "aws_ssm_parameter" "cloudfront_distribution_id" {
+  name  = "${var.environment_name}-prsdb-cloudfront-distribution-id"
+  type  = "String"
+  value = aws_cloudfront_distribution.main.id
+}

--- a/terraform/modules/monitoring/resource_alarms.tf
+++ b/terraform/modules/monitoring/resource_alarms.tf
@@ -203,3 +203,26 @@ resource "aws_cloudwatch_metric_alarm" "alb_no_healthy_hosts" {
     aws_sns_topic.critical_alarm_sns_topic.arn,
   ]
 }
+
+resource "aws_cloudwatch_metric_alarm" "alb_unhealthy_hosts" {
+  alarm_name          = "${var.alb_name}-unhealthy-hosts"
+  alarm_description   = "One or more ALB targets have been failing their health check, indicating a failed deployment"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  metric_name         = "UnHealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  evaluation_periods  = 12
+  period              = 300
+  datapoints_to_alarm = 1
+  threshold           = 1
+  statistic           = "Maximum"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+    TargetGroup  = var.alb_target_group_arn_suffix
+  }
+
+  alarm_actions = [
+    aws_sns_topic.critical_alarm_sns_topic.arn,
+  ]
+}

--- a/terraform/modules/monitoring/webapp_metrics_publishing.tf
+++ b/terraform/modules/monitoring/webapp_metrics_publishing.tf
@@ -1,11 +1,13 @@
 # Allows the webapp ECS task role to publish JVM/process metrics to CloudWatch
-# via Micrometer's CloudWatch registry.
-# cloudwatch:PutMetricData does not support resource-level permissions, so a wildcard is required.
+# via Micrometer's CloudWatch registry, and to read infrastructure metrics back via
+# GetMetricStatistics to power the System Operator dashboard.
+# Neither cloudwatch:PutMetricData nor cloudwatch:GetMetricStatistics supports
+# resource-level permissions, so a wildcard is required.
 # See https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudwatch.html
 # tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "webapp_publish_cloudwatch_metrics" {
   statement {
-    actions   = ["cloudwatch:PutMetricData"]
+    actions   = ["cloudwatch:PutMetricData", "cloudwatch:GetMetricStatistics"]
     resources = ["*"]
     effect    = "Allow"
   }

--- a/terraform/modules/secrets/iam.tf
+++ b/terraform/modules/secrets/iam.tf
@@ -48,6 +48,7 @@ resource "aws_iam_role_policy" "secret_access" {
           aws_secretsmanager_secret.one_login_private_key.arn,
           aws_secretsmanager_secret.notify_api_key.arn,
           aws_secretsmanager_secret.os_api_key.arn,
+          aws_secretsmanager_secret.plausible_api_key.arn,
           aws_secretsmanager_secret.epc_register_client_secret.arn,
           aws_secretsmanager_secret.internal_access_client_secret.arn,
         ]

--- a/terraform/modules/secrets/secrets.tf
+++ b/terraform/modules/secrets/secrets.tf
@@ -53,6 +53,13 @@ resource "aws_secretsmanager_secret" "os_api_key" {
   kms_key_id              = aws_kms_key.prsdb_webapp_secrets.arn
 }
 
+resource "aws_secretsmanager_secret" "plausible_api_key" {
+  name                    = "tf-${var.environment_name}-prsdb-plausible-api-key"
+  description             = "API key for Plausible analytics"
+  recovery_window_in_days = 0
+  kms_key_id              = aws_kms_key.prsdb_webapp_secrets.arn
+}
+
 resource "aws_secretsmanager_secret" "epc_register_client_secret" {
   name                    = "tf-${var.environment_name}-prsdb-epc-client-secret"
   description             = "Client secret for the EPC register client secret"

--- a/terraform/modules/ssm/parameters.tf
+++ b/terraform/modules/ssm/parameters.tf
@@ -122,6 +122,16 @@ resource "aws_ssm_parameter" "plausible_site_id" {
   }
 }
 
+resource "aws_ssm_parameter" "plausible_domain_id" {
+  name  = "${var.environment_name}-prsdb-plausible-domain-id"
+  type  = "String"
+  value = "default_to_be_set_manually" # To be set manually on AWS
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
 resource "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name  = "${var.environment_name}-prsdb-beta-feedback-team-email-address"
   type  = "String"

--- a/terraform/modules/ssm/parameters.tf
+++ b/terraform/modules/ssm/parameters.tf
@@ -132,6 +132,16 @@ resource "aws_ssm_parameter" "plausible_domain_id" {
   }
 }
 
+resource "aws_ssm_parameter" "plausible_transaction_event_start_date" {
+  name  = "${var.environment_name}-prsdb-plausible-transaction-event-start-date"
+  type  = "String"
+  value = "2099-01-01" # Far-future default keeps the metric on the legacy method; set the real go-live date manually on AWS
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
 resource "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name  = "${var.environment_name}-prsdb-beta-feedback-team-email-address"
   type  = "String"

--- a/terraform/nft/ecs_task_definition/data.tf
+++ b/terraform/nft/ecs_task_definition/data.tf
@@ -116,6 +116,10 @@ data "aws_ssm_parameter" "plausible_site_id" {
   name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
+data "aws_ssm_parameter" "plausible_domain_id" {
+  name = "${local.environment_name}-prsdb-plausible-domain-id"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/nft/ecs_task_definition/data.tf
+++ b/terraform/nft/ecs_task_definition/data.tf
@@ -42,6 +42,23 @@ data "aws_ssm_parameter" "redis_port" {
   name = "${local.environment_name}-prsdb-redis-port"
 }
 
+# CloudWatch metric dimension identifiers read by the System Operator dashboard.
+data "aws_ssm_parameter" "ecs_cluster_name" {
+  name = "${local.environment_name}-prsdb-ecs-cluster-name"
+}
+
+data "aws_ssm_parameter" "ecs_service_name" {
+  name = "${local.environment_name}-prsdb-ecs-service-name"
+}
+
+data "aws_ssm_parameter" "redis_cluster_id" {
+  name = "${local.environment_name}-prsdb-redis-cluster-id"
+}
+
+data "aws_ssm_parameter" "cloudfront_distribution_id" {
+  name = "${local.environment_name}-prsdb-cloudfront-distribution-id"
+}
+
 data "aws_secretsmanager_secret" "redis_password" {
   name = "tf-${local.environment_name}-prsdb-redis-password"
 }

--- a/terraform/nft/ecs_task_definition/data.tf
+++ b/terraform/nft/ecs_task_definition/data.tf
@@ -70,6 +70,10 @@ data "aws_secretsmanager_secret" "os_api_key" {
   name = "tf-${local.environment_name}-os-api-key"
 }
 
+data "aws_secretsmanager_secret" "plausible_api_key" {
+  name = "tf-${local.environment_name}-prsdb-plausible-api-key"
+}
+
 data "aws_ssm_parameter" "quarantine_bucket" {
   count = var.file_upload_buckets_created ? 1 : 0
   name  = "${local.environment_name}-prsdb-quarantine-bucket"

--- a/terraform/nft/ecs_task_definition/data.tf
+++ b/terraform/nft/ecs_task_definition/data.tf
@@ -137,6 +137,10 @@ data "aws_ssm_parameter" "plausible_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-domain-id"
 }
 
+data "aws_ssm_parameter" "plausible_transaction_event_start_date" {
+  name = "${local.environment_name}-prsdb-plausible-transaction-event-start-date"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -169,6 +169,10 @@ locals {
       name      = "INTERNAL_ACCESS_CLIENT_SECRET"
       valueFrom = data.aws_secretsmanager_secret.internal_access_client_secret.arn
     },
+    {
+      name      = "PLAUSIBLE_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.plausible_api_key.arn
+    },
   ]
 }
 

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -119,6 +119,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
+      name  = "PLAUSIBLE_DOMAIN_ID"
+      value = data.aws_ssm_parameter.plausible_domain_id.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}"
     },

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -64,6 +64,22 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "CLOUDWATCH_ECS_CLUSTER_NAME"
+      value = data.aws_ssm_parameter.ecs_cluster_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ECS_SERVICE_NAME"
+      value = data.aws_ssm_parameter.ecs_service_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ELASTICACHE_CLUSTER_ID"
+      value = data.aws_ssm_parameter.redis_cluster_id.value
+    },
+    {
+      name  = "CLOUDFRONT_DISTRIBUTION_ID"
+      value = data.aws_ssm_parameter.cloudfront_distribution_id.value
+    },
   ]
   webapp_only_environment_variables = [
     {

--- a/terraform/nft/ecs_task_definition/main.tf
+++ b/terraform/nft/ecs_task_definition/main.tf
@@ -139,6 +139,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_domain_id.value
     },
     {
+      name  = "PLAUSIBLE_TRANSACTION_EVENT_START_DATE"
+      value = data.aws_ssm_parameter.plausible_transaction_event_start_date.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}"
     },

--- a/terraform/production/ecs_task_definition/data.tf
+++ b/terraform/production/ecs_task_definition/data.tf
@@ -116,6 +116,10 @@ data "aws_ssm_parameter" "plausible_site_id" {
   name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
+data "aws_ssm_parameter" "plausible_domain_id" {
+  name = "${local.environment_name}-prsdb-plausible-domain-id"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/production/ecs_task_definition/data.tf
+++ b/terraform/production/ecs_task_definition/data.tf
@@ -42,6 +42,23 @@ data "aws_ssm_parameter" "redis_port" {
   name = "${local.environment_name}-prsdb-redis-port"
 }
 
+# CloudWatch metric dimension identifiers read by the System Operator dashboard.
+data "aws_ssm_parameter" "ecs_cluster_name" {
+  name = "${local.environment_name}-prsdb-ecs-cluster-name"
+}
+
+data "aws_ssm_parameter" "ecs_service_name" {
+  name = "${local.environment_name}-prsdb-ecs-service-name"
+}
+
+data "aws_ssm_parameter" "redis_cluster_id" {
+  name = "${local.environment_name}-prsdb-redis-cluster-id"
+}
+
+data "aws_ssm_parameter" "cloudfront_distribution_id" {
+  name = "${local.environment_name}-prsdb-cloudfront-distribution-id"
+}
+
 data "aws_secretsmanager_secret" "redis_password" {
   name = "tf-${local.environment_name}-prsdb-redis-password"
 }

--- a/terraform/production/ecs_task_definition/data.tf
+++ b/terraform/production/ecs_task_definition/data.tf
@@ -70,6 +70,10 @@ data "aws_secretsmanager_secret" "os_api_key" {
   name = "tf-${local.environment_name}-os-api-key"
 }
 
+data "aws_secretsmanager_secret" "plausible_api_key" {
+  name = "tf-${local.environment_name}-prsdb-plausible-api-key"
+}
+
 data "aws_ssm_parameter" "quarantine_bucket" {
   count = var.file_upload_buckets_created ? 1 : 0
   name  = "${local.environment_name}-prsdb-quarantine-bucket"

--- a/terraform/production/ecs_task_definition/data.tf
+++ b/terraform/production/ecs_task_definition/data.tf
@@ -137,6 +137,10 @@ data "aws_ssm_parameter" "plausible_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-domain-id"
 }
 
+data "aws_ssm_parameter" "plausible_transaction_event_start_date" {
+  name = "${local.environment_name}-prsdb-plausible-transaction-event-start-date"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -169,6 +169,10 @@ locals {
       name      = "INTERNAL_ACCESS_CLIENT_SECRET"
       valueFrom = data.aws_secretsmanager_secret.internal_access_client_secret.arn
     },
+    {
+      name      = "PLAUSIBLE_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.plausible_api_key.arn
+    },
   ]
 }
 

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -64,6 +64,22 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "CLOUDWATCH_ECS_CLUSTER_NAME"
+      value = data.aws_ssm_parameter.ecs_cluster_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ECS_SERVICE_NAME"
+      value = data.aws_ssm_parameter.ecs_service_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ELASTICACHE_CLUSTER_ID"
+      value = data.aws_ssm_parameter.redis_cluster_id.value
+    },
+    {
+      name  = "CLOUDFRONT_DISTRIBUTION_ID"
+      value = data.aws_ssm_parameter.cloudfront_distribution_id.value
+    },
   ]
   webapp_only_environment_variables = [
     {

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -139,6 +139,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_domain_id.value
     },
     {
+      name  = "PLAUSIBLE_TRANSACTION_EVENT_START_DATE"
+      value = data.aws_ssm_parameter.plausible_transaction_event_start_date.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },

--- a/terraform/production/ecs_task_definition/main.tf
+++ b/terraform/production/ecs_task_definition/main.tf
@@ -119,6 +119,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
+      name  = "PLAUSIBLE_DOMAIN_ID"
+      value = data.aws_ssm_parameter.plausible_domain_id.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -116,6 +116,10 @@ data "aws_ssm_parameter" "plausible_site_id" {
   name = "${local.environment_name}-prsdb-plausible-site-id"
 }
 
+data "aws_ssm_parameter" "plausible_domain_id" {
+  name = "${local.environment_name}-prsdb-plausible-domain-id"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -42,6 +42,23 @@ data "aws_ssm_parameter" "redis_port" {
   name = "${local.environment_name}-prsdb-redis-port"
 }
 
+# CloudWatch metric dimension identifiers read by the System Operator dashboard.
+data "aws_ssm_parameter" "ecs_cluster_name" {
+  name = "${local.environment_name}-prsdb-ecs-cluster-name"
+}
+
+data "aws_ssm_parameter" "ecs_service_name" {
+  name = "${local.environment_name}-prsdb-ecs-service-name"
+}
+
+data "aws_ssm_parameter" "redis_cluster_id" {
+  name = "${local.environment_name}-prsdb-redis-cluster-id"
+}
+
+data "aws_ssm_parameter" "cloudfront_distribution_id" {
+  name = "${local.environment_name}-prsdb-cloudfront-distribution-id"
+}
+
 data "aws_secretsmanager_secret" "redis_password" {
   name = "tf-${local.environment_name}-prsdb-redis-password"
 }

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -70,6 +70,10 @@ data "aws_secretsmanager_secret" "os_api_key" {
   name = "tf-${local.environment_name}-os-api-key"
 }
 
+data "aws_secretsmanager_secret" "plausible_api_key" {
+  name = "tf-${local.environment_name}-prsdb-plausible-api-key"
+}
+
 data "aws_ssm_parameter" "quarantine_bucket" {
   count = var.file_upload_buckets_created ? 1 : 0
   name  = "${local.environment_name}-prsdb-quarantine-bucket"

--- a/terraform/test/ecs_task_definition/data.tf
+++ b/terraform/test/ecs_task_definition/data.tf
@@ -137,6 +137,10 @@ data "aws_ssm_parameter" "plausible_domain_id" {
   name = "${local.environment_name}-prsdb-plausible-domain-id"
 }
 
+data "aws_ssm_parameter" "plausible_transaction_event_start_date" {
+  name = "${local.environment_name}-prsdb-plausible-transaction-event-start-date"
+}
+
 data "aws_ssm_parameter" "beta_feedback_team_email_address" {
   name = "${local.environment_name}-prsdb-beta-feedback-team-email-address"
 }

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -169,6 +169,10 @@ locals {
       name      = "INTERNAL_ACCESS_CLIENT_SECRET"
       valueFrom = data.aws_secretsmanager_secret.internal_access_client_secret.arn
     },
+    {
+      name      = "PLAUSIBLE_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.plausible_api_key.arn
+    },
   ]
 }
 

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -64,6 +64,22 @@ locals {
       name  = "METRICS_CLOUDWATCH_NAMESPACE"
       value = "prsdb-webapp/${local.environment_name}"
     },
+    {
+      name  = "CLOUDWATCH_ECS_CLUSTER_NAME"
+      value = data.aws_ssm_parameter.ecs_cluster_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ECS_SERVICE_NAME"
+      value = data.aws_ssm_parameter.ecs_service_name.value
+    },
+    {
+      name  = "CLOUDWATCH_ELASTICACHE_CLUSTER_ID"
+      value = data.aws_ssm_parameter.redis_cluster_id.value
+    },
+    {
+      name  = "CLOUDFRONT_DISTRIBUTION_ID"
+      value = data.aws_ssm_parameter.cloudfront_distribution_id.value
+    },
   ]
   webapp_only_environment_variables = [
     {

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -139,6 +139,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_domain_id.value
     },
     {
+      name  = "PLAUSIBLE_TRANSACTION_EVENT_START_DATE"
+      value = data.aws_ssm_parameter.plausible_transaction_event_start_date.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },

--- a/terraform/test/ecs_task_definition/main.tf
+++ b/terraform/test/ecs_task_definition/main.tf
@@ -119,6 +119,10 @@ locals {
       value = data.aws_ssm_parameter.plausible_site_id.value
     },
     {
+      name  = "PLAUSIBLE_DOMAIN_ID"
+      value = data.aws_ssm_parameter.plausible_domain_id.value
+    },
+    {
       name  = "SPRING_PROFILES_ACTIVE"
       value = "default, ${local.environment_name}, require-passcode"
     },


### PR DESCRIPTION
## Release notes

PDJB-1035: Add PLAUSIBLE_API_KEY secret and plausible-domain-id SSM parameter
PDJB-1034: Add CloudWatch metric read env vars, GetMetricStatistics permission, and PLAUSIBLE_TRANSACTION_EVENT_START_DATE env var
PDJB-1202: Fix WAF rules false positives on file uploads
PDJB-1092: Add healthcheck failure alarm
PDJB-NONE: Run task-def refresh after main infra apply, add instructions for triggering scheduled tasks for QA