### PR TITLE
PDJB-1036: Grant ECS task Cost Explorer permissions

### DIFF
--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -63,6 +63,6 @@ variable "alb_target_group_arn_suffix" {
 }
 
 variable "webapp_ecs_task_role_name" {
-  description = "Name of the webapp ECS task role to grant CloudWatch metric publishing permissions to"
+  description = "Name of the webapp ECS task role to grant monitoring permissions to"
   type        = string
 }

--- a/terraform/modules/monitoring/webapp_cost_explorer_access.tf
+++ b/terraform/modules/monitoring/webapp_cost_explorer_access.tf
@@ -1,0 +1,22 @@
+# Allows the webapp ECS task role to query historical costs for the
+# System Operator metrics dashboard's cost-per-transaction calculation.
+# ce:GetCostAndUsage does not support resource-level permissions, so a wildcard is required.
+# See https://docs.aws.amazon.com/service-authorization/latest/reference/list_awscostexplorerservice.html
+# tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "webapp_cost_explorer_access" {
+  statement {
+    actions   = ["ce:GetCostAndUsage"]
+    resources = ["*"]
+    effect    = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "webapp_cost_explorer_access" {
+  name   = "${var.environment_name}-webapp-read-cost-and-usage"
+  policy = data.aws_iam_policy_document.webapp_cost_explorer_access.json
+}
+
+resource "aws_iam_role_policy_attachment" "webapp_cost_explorer_access" {
+  role       = var.webapp_ecs_task_role_name
+  policy_arn = aws_iam_policy.webapp_cost_explorer_access.arn
+}

--- a/terraform/modules/monitoring/webapp_cost_explorer_access.tf
+++ b/terraform/modules/monitoring/webapp_cost_explorer_access.tf
@@ -1,12 +1,11 @@
 # Allows the webapp ECS task role to query historical costs for the
 # System Operator metrics dashboard's cost-per-transaction calculation.
-# ce:GetCostAndUsage does not support resource-level permissions, so a wildcard is required.
-# See https://docs.aws.amazon.com/service-authorization/latest/reference/list_awscostexplorerservice.html
-# tfsec:ignore:aws-iam-no-policy-wildcards
+# Cost Explorer queries default to the account's primary billing view.
+# See https://docs.aws.amazon.com/service-authorization/latest/reference/list_ce.html#list_ce-action-GetCostAndUsage
 data "aws_iam_policy_document" "webapp_cost_explorer_access" {
   statement {
     actions   = ["ce:GetCostAndUsage"]
-    resources = ["*"]
+    resources = ["arn:aws:billing::${data.aws_caller_identity.current.account_id}:billingview/primary"]
     effect    = "Allow"
   }
 }


### PR DESCRIPTION
## Ticket number

PDJB-1036

## Goal of change

Allow the PRSDB webapp ECS task to query historical AWS costs for the metrics dashboard's cost-per-transaction calculation.

## Description of main change(s)

- Adds a dedicated IAM policy granting only `ce:GetCostAndUsage`.
- Attaches the policy to the webapp ECS task role through the existing monitoring module in integration, test, nft, and production.
- Scopes access to the AWS account's primary billing view rather than all resources.

## Anything you'd like to highlight to the reviewer?

The webapp Cost Explorer integration has not been implemented yet. This PR establishes `GetCostAndUsage` as the least-privilege API contract and deliberately avoids broader `ce:Get*` permissions.

Following review, the policy now targets `arn:aws:billing::<account-id>:billingview/primary`, which AWS documents as a supported resource for `GetCostAndUsage`.

Authenticated Terraform plans and deployment verification require AWS account access. Cost Explorer enablement could not be confirmed locally and must be checked in the AWS Organizations management/billing account before the dashboard query is exercised.

Verification completed locally with Terraform 1.9.1 formatting and validation for all four environments, tflint 0.54.0, and tfsec 1.28.11.

## Checklist

- [ ] Any special release instructions (e.g. set environment variables) have been added as checklist items to a draft PR (merging `main` into `test`) for the next release.

  Outstanding: add a release checklist item to confirm that Cost Explorer is enabled and has populated cost data in the management/billing account. If the webapp query filters by billing tags, confirm those cost allocation tags are activated.